### PR TITLE
overloaded parameter directive

### DIFF
--- a/src/main/scala/cc/spray/builders/ParameterBuilders.scala
+++ b/src/main/scala/cc/spray/builders/ParameterBuilders.scala
@@ -27,6 +27,12 @@ private[spray] trait ParameterBuilders {
   def parameter (a: Param) = filter1[String](build(a :: Nil))
 
   /**
+   * Returns a Route that rejects the request if a query parameter with the given name cannot be found.
+   * If it can be found the parameters value is extracted and passed as argument to the inner Route building function.
+   */
+  def parameters (a: Param) = filter1[String](build(a :: Nil))
+
+  /**
    * Returns a Route that rejects the request if the query parameters with the given names cannot be found.
    * If it can be found the parameter values are extracted and passed as arguments to the inner Route building function.
    */
@@ -73,6 +79,17 @@ private[spray] trait ParameterBuilders {
     ctx.request.queryParams.get(p.name) match {
       case Some(value) if value == p.requiredValue => Pass()
       case _ => Reject() 
+    }
+  }
+
+  /**
+   * Returns a Route that rejects the request if the query parameter with the given name cannot be found or does not
+   * have the required value.
+   */
+  def parameters(p: RequiredParameter) = filter { ctx =>
+    ctx.request.queryParams.get(p.name) match {
+      case Some(value) if value == p.requiredValue => Pass()
+      case _ => Reject()
     }
   }
   

--- a/src/test/scala/cc/spray/builders/ParameterBuildersSpec.scala
+++ b/src/test/scala/cc/spray/builders/ParameterBuildersSpec.scala
@@ -61,6 +61,15 @@ class ParameterBuildersSpec extends Specification with SprayTest with ServiceBui
         }
       }.response.content.as[String] mustEqual Right("EllenParsons29")
     }
+    "accept a single parameter to the plural form" in {
+      test(HttpRequest(uri = "/person?name=Charlie")) {
+        path("person") {
+          parameters("name") { (name) =>
+            get { _.complete(name) }
+          }
+        }
+      }.response.content.as[String] mustEqual Right("Charlie")
+    }
   }
   
   "The 'parameter' requirement directive" should {
@@ -99,6 +108,13 @@ class ParameterBuildersSpec extends Specification with SprayTest with ServiceBui
       test(HttpRequest(uri = "/person")) {
         route 
       }.response.content.as[String] mustEqual Right("GET")
+    }
+    "accept a single parameter to the plural form" in {
+      test(HttpRequest(uri = "/person?name=Charlie")) {
+        path("person") {
+          parameters('name ! "Charlie") { _.complete("yes") }
+        }
+      }.response.content.as[String] mustEqual Right("yes")
     }
   }
 


### PR DESCRIPTION
Overloaded single argument 'parameter' with 'parameters' so the same directive can be used regardless of number of arguments. The two different directives tripped me up a bit.

Also overloaded the single-argument required parameter directive.

Tests included.
