### PR TITLE
Added support for the 'boundary' parameter of the Content-Type header

### DIFF
--- a/spray-examples/spray-example-calculator/src/main/scala/cc/spray/examples/calculator/CustomMarshallers.scala
+++ b/spray-examples/spray-example-calculator/src/main/scala/cc/spray/examples/calculator/CustomMarshallers.scala
@@ -11,8 +11,8 @@ trait CustomMarshallers {
     val canMarshalTo = ContentType(`text/xml`) :: ContentType(`text/plain`) :: Nil
 
     def marshal(value: Double, contentType: ContentType) = contentType match {
-      case x@ ContentType(`text/xml`, _) => HttpContent(x, "<double>" + value + "</double>")  
-      case x@ ContentType(`text/plain`, _) => HttpContent(x, value.toString)
+      case x@ ContentType(`text/xml`, _, _) => HttpContent(x, "<double>" + value + "</double>")
+      case x@ ContentType(`text/plain`, _, _) => HttpContent(x, value.toString)
       case _ => throw new IllegalArgumentException
     }
   }

--- a/spray-examples/spray-example-markdownserver/src/main/scala/cc/spray/examples/markdownserver/MarkdownService.scala
+++ b/spray-examples/spray-example-markdownserver/src/main/scala/cc/spray/examples/markdownserver/MarkdownService.scala
@@ -23,7 +23,7 @@ trait MarkdownService extends Directives {
   def rewritePath(path: String) = (if (path.isEmpty) "index" else path) + ".markdown"
   
   def markdown2Html(content: HttpContent) = content.contentType match {
-    case ContentType(MarkdownType, _) => {
+    case ContentType(MarkdownType, _, _) => {
       val html = new PegDownProcessor(Extensions.ALL).markdownToHtml(content.as[String].right.get) 
       HttpContent(ContentType(`text/html`), html) 
     }

--- a/spray-examples/spray-example-stopwatch/src/main/scala/cc/spray/examples/stopwatch/StopWatchMarshallers.scala
+++ b/spray-examples/spray-example-stopwatch/src/main/scala/cc/spray/examples/stopwatch/StopWatchMarshallers.scala
@@ -17,7 +17,7 @@ trait StopWatchMarshallers extends DefaultMarshallers {
     val canMarshalTo = ContentType(`text/html`) :: Nil
 
     def marshal(value: Map[Int, StopWatch], contentType: ContentType) = contentType match {
-      case x@ ContentType(`text/html`, _) => NodeSeqMarshaller.marshal(marshalToHtml(value), x)  
+      case x@ ContentType(`text/html`, _, _) => NodeSeqMarshaller.marshal(marshalToHtml(value), x)
       case _ => throw new IllegalArgumentException
     }
     
@@ -55,7 +55,7 @@ trait StopWatchMarshallers extends DefaultMarshallers {
     val canMarshalTo = ContentType(`text/html`) :: Nil
 
     def marshal(value: StopWatch, contentType: ContentType) = contentType match {
-      case x@ ContentType(`text/html`, _) => NodeSeqMarshaller.marshal(marshalToHtml(value), x)    
+      case x@ ContentType(`text/html`, _, _) => NodeSeqMarshaller.marshal(marshalToHtml(value), x)
       case _ => throw new IllegalArgumentException
     }
     

--- a/spray-examples/spray-example-stopwatch/src/main/scala/cc/spray/examples/stopwatch/StopWatchService.scala
+++ b/spray-examples/spray-example-stopwatch/src/main/scala/cc/spray/examples/stopwatch/StopWatchService.scala
@@ -89,7 +89,7 @@ trait StopWatchService extends Directives with StopWatchMarshallers {
   }
   
   def wrapWithBackLink(content: HttpContent) = content.contentType match {
-    case ContentType(`text/plain`, charset) => {
+    case ContentType(`text/plain`, charset, boundary) => {
       val html =
         <html>
           <body>
@@ -97,7 +97,7 @@ trait StopWatchService extends Directives with StopWatchMarshallers {
             <a href="/watches">Back</a>
           </body>
         </html>
-      NodeSeqMarshaller.marshal(html, ContentType(`text/html`, charset))
+      NodeSeqMarshaller.marshal(html, ContentType(`text/html`, charset, boundary))
     }
     case _ => content
   }

--- a/spray-http/src/main/scala/cc/spray/http/ContentType.scala
+++ b/spray-http/src/main/scala/cc/spray/http/ContentType.scala
@@ -30,12 +30,14 @@ case class ContentTypeRange(mediaRange: MediaRange, charsetRange: HttpCharsetRan
   override def toString = "ContentTypeRange(" + value + ')'
 }
 
-case class ContentType(mediaType: MediaType, charset: Option[HttpCharset]) {
-  def value: String = charset match {
-    // don't print the charset parameter if it's the default charset
-    case Some(cs) if (!mediaType.isText || cs != `ISO-8859-1`)=> mediaType.value + "; charset=" + cs.value
-    case _ => mediaType.value
-  }
+case class ContentType(mediaType: MediaType, charset: Option[HttpCharset], boundary: Option[String]) {
+  def value: String = mediaType.value +
+                      (charset match {
+                        // don't print the charset parameter if it's the default charset
+                        case Some(cs) if (!mediaType.isText || cs != `ISO-8859-1`)=> "; charset=" + cs.value
+                        case _ => ""
+                      }) +
+                      boundary.map("; boundary=" + _).getOrElse("")
 
   override def equals(obj: Any) = obj match {
     case x: ContentType => mediaType == x.mediaType && charset == x.charset
@@ -44,8 +46,8 @@ case class ContentType(mediaType: MediaType, charset: Option[HttpCharset]) {
 }
 
 object ContentType {
-  def apply(mediaType: MediaType, charset: HttpCharset): ContentType = apply(mediaType, Some(charset))
-  def apply(mediaType: MediaType): ContentType = apply(mediaType, None)
+  def apply(mediaType: MediaType, charset: HttpCharset): ContentType = apply(mediaType, Some(charset), None)
+  def apply(mediaType: MediaType): ContentType = apply(mediaType, None, None)
   
   implicit def fromMimeType(mimeType: MediaType): ContentType = apply(mimeType) 
 }                     

--- a/spray-http/src/main/scala/cc/spray/http/parser/ContentTypeHeader.scala
+++ b/spray-http/src/main/scala/cc/spray/http/parser/ContentTypeHeader.scala
@@ -34,14 +34,14 @@ private[parser] trait ContentTypeHeader {
   
   private def createContentTypeHeader(mainType: String, subType: String, params: Map[String, String]) = {
     val mimeType = getMediaType(mainType, subType)
-    params.get("charset").map { charsetName =>
+    val charset = params.get("charset").map { charsetName =>
       HttpCharsets.getForKey(charsetName.toLowerCase).getOrElse {
         throw new HttpException(BadRequest, "Unsupported charset: " + charsetName)
       }
-    } match {
-      case Some(charset) => `Content-Type`(ContentType(mimeType, charset)) 
-      case None => `Content-Type`(ContentType(mimeType)) 
     }
-  } 
+    val boundary = params.get("boundary")
+
+    `Content-Type`(ContentType(mimeType, charset, boundary))
+  }
   
 }

--- a/spray-http/src/test/scala/cc/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/cc/spray/http/HttpHeaderSpec.scala
@@ -119,6 +119,7 @@ class HttpHeaderSpec extends Specification {
     import HttpCharsets._
     "be parsed correctly from various examples" in {
       HttpHeader("Content-Type", "application/pdf") mustEqual `Content-Type`(`application/pdf`)
+      HttpHeader("Content-Type", "multipart/form-data; boundary=ABC123") mustEqual `Content-Type`(ContentType(`multipart/form-data`, None, Some("ABC123")))
       HttpHeader("Content-Type", "text/plain; charset=utf8") mustEqual `Content-Type`(ContentType(`text/plain`, `UTF-8`))
     }
   }

--- a/spray-server/src/main/scala/cc/spray/directives/MiscDirectives.scala
+++ b/spray-server/src/main/scala/cc/spray/directives/MiscDirectives.scala
@@ -82,7 +82,7 @@ private[spray] trait MiscDirectives {
    * one.
    */
   def respondWithMediaType(mediaType: MediaType) = transformResponse { response =>
-    response.copy(content = response.content.map(c => c.withContentType(ContentType(mediaType, c.contentType.charset))))
+    response.copy(content = response.content.map(c => c.withContentType(ContentType(mediaType, c.contentType.charset, None))))
   }
 
   /**
@@ -97,8 +97,8 @@ private[spray] trait MiscDirectives {
         import MediaTypes._
         import marshalling.DefaultUnmarshallers._
         (ctx.request.queryParams.get(parameterName), content.contentType) match {
-          case (Some(wrapper), ContentType(`application/json`, charset)) =>
-            HttpContent(ContentType(`application/javascript`, charset), wrapper + '(' + content.as[String].right.get + ')')
+          case (Some(wrapper), ContentType(`application/json`, charset, boundary)) =>
+            HttpContent(ContentType(`application/javascript`, charset, boundary), wrapper + '(' + content.as[String].right.get + ')')
           case _ => content
         }
       }


### PR DESCRIPTION
Added support for the 'boundary' parameter of the Content-Type header. This is necessary for being able to implement multipart/\* marshalling. I intend to implement this as well tomorrow.

Note: the test of the sample StopWatch service do not pass anymore, but it does not seem related. The resource file being loaded ('main.html') is loaded from the project module, not the test one anymore. I have no idea why.

I am not very familiar with open source projects contribution, so any feedback, positive or negative, is welcome.

Julien
