### PR TITLE
Removed double registration of the ioBridge shutdown hook in the simple-spray-client example

### DIFF
--- a/examples/spray-client/simple-spray-client/src/main/scala/cc/spray/examples/Main.scala
+++ b/examples/spray-client/simple-spray-client/src/main/scala/cc/spray/examples/Main.scala
@@ -29,12 +29,6 @@ object Main extends App {
 
   startExample1()
 
-  // finally we drop the main thread but hook the shutdown of
-  // our IOBridge into the shutdown of the applications ActorSystem
-  system.registerOnTermination {
-    ioBridge.stop()
-  }
-
   ///////////////////////////////////////////////////
 
   def startExample1() {


### PR DESCRIPTION
I noticed that the shutdown hook got registered twice in the simple-spray-client example. I decided to remove the second registration because the first one had better documentation and was closer to where the ioBridge gets created.

On a side note: I also noticed that only one of the conduits gets explicitly stopped while others are left alive. It is not clear from the example why that one conduit is stopped, why in that case, and why not in the other cases.
