### PR TITLE
Minor Documentation Link Fixes

### DIFF
--- a/docs/documentation/spray-routing/getting-started.rst
+++ b/docs/documentation/spray-routing/getting-started.rst
@@ -7,6 +7,6 @@ github that you can clone and use as a basis. They live in two branches of the s
 - Clone the on_spray-can_ branch, if you'd like to run *spray-routing* on :ref:`spray-can`
 - Clone the on_jetty_ branch, if you'd like to run *spray-routing* on :ref:`spray-servlet`
 
-.. _spray-template: https://github.com/spray/spray-template
-.. _on_spray-can: https://github.com/spray/spray-template/tree/on_spray-can
-.. _on_jetty: https://github.com/spray/spray-template/tree/on_jetty
+.. _spray-template: https://github.com/spray/spray-template/
+.. _on_spray-can: https://github.com/spray/spray-template/tree/on_spray-can_1.1
+.. _on_jetty: https://github.com/spray/spray-template/tree/on_jetty_1.1


### PR DESCRIPTION
Hello,

I was looking through the documentation for spray-routing and noticed a couple of broken links so I fixed them.  I didn't actually look at how to generate the documentation into HTML, so it wouldn't hurt just to quickly check the links once the documentation gets regenerated.  I did copy and paste each URL into my browser to make sure they worked though.

Thanks,

Brandon
