### PR TITLE
Modify spray-can to allow dynamic User-Agent header

### DIFF
--- a/spray-can/src/main/scala/spray/can/rendering/RequestRenderer.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RequestRenderer.scala
@@ -80,7 +80,8 @@ class RequestRenderer(userAgentHeader: String, requestSizeHint: Int) extends Mes
         case "content-type"      => // we never render these headers here,
         case "content-length"    => // because their production is the
         case "transfer-encoding" => // responsibility of the spray-can layer,
-        case "user-agent"        => // not the user
+        case "user-agent" if !userAgentHeader.isEmpty
+                                 => // not the user
         case "host"              => newHostHeaderPresent = true; appendHeader(header, bb)
         case _                   => appendHeader(header, bb)
       }


### PR DESCRIPTION
- Client is allowed to set only when spray.can.client.user-agent-header setting is blank
- This fixes #193
