### PR TITLE
Scalatest: BeforeAndAfterAll can be stacked

### DIFF
--- a/spray-testkit/src/main/scala/spray/testkit/ScalatestInterface.scala
+++ b/spray-testkit/src/main/scala/spray/testkit/ScalatestInterface.scala
@@ -25,5 +25,8 @@ trait ScalatestInterface extends TestFrameworkInterface with BeforeAndAfterAll {
 
   def failTest(msg: String) = throw new TestFailedException(msg, 11)
 
-  override protected def afterAll() { cleanUp() }
+  override protected def afterAll() { 
+    cleanUp() 
+    super.afterAll()
+  }
 }


### PR DESCRIPTION
When using scalatest and spray-testkit, there may be multiple traits implementing BeforeAndAfterAll in a test.
To ensure that all of them are called, ScalatestInterface should call the super implementation. 
