### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,6 @@
+-Dfile.encoding=UTF8
+-XX:MaxPermSize=512m
+-Xms512m
+-Xss2m
+-XX:+CMSClassUnloadingEnabled
+-XX:+UseConcMarkSweepGC

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: scala
+script: 
+  - sbt ++$TRAVIS_SCALA_VERSION compile test:compile
+  - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=1.5 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)' test
+scala:
+  - 2.10.1
+jdk:
+  - oraclejdk7
+  - openjdk7
+notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/notifications/ to learn more
+  # about configuring notification recipients and more (e.g. IRC notifications).
+  email: false

--- a/README.markdown
+++ b/README.markdown
@@ -1,1 +1,7 @@
+# Documentation
+
 Please see <http://spray.io/> for all documentation
+
+# Code Climate
+
+[![Build Status](https://travis-ci.org/spray/spray.png?branch=master)](https://travis-ci.org/spray/spray)


### PR DESCRIPTION
I recently discovered Spray project (:heart:), and feel that it should definitely take advantage of Travis CI goodies ("on push" continuous integration, pull request validation, etc). Unfortunately, there is some(small)thing to fix to get it to work at 100%... but it's very close!
- When using Travis default build command for Scala/sbt (`sbt test` in this case), the project test suite fails (at the moment) for [one single error](https://travis-ci.org/gildegoma/spray/jobs/5242314/#L1488).
- When I ran the build in two phases (`sbt compile test`) as recommended by Spray documentation, the test suite still failed for [the same error](https://travis-ci.org/gildegoma/spray/jobs/5242839/#L1422).
- On a local (mac os x) box, I could build the same code revision without any error, hence looking for troubleshooting the travis integration...

Below my list of open points around this pull request:
- Make the build pass in Travis CI environment :traffic_light: 
- Implement support of Sphinx tests ([`SPHINX_PATH` is not yet enabled in CI environment](https://travis-ci.org/gildegoma/spray/jobs/5242839/#L711))
- _Any other "CI" points to address ?_ (I am VERY newcomer to Spray, so I may have missed a LOT of things)

If you're interested in such integration, just know that I'm ready and happy to help you to make Spray running on Travis.
