### PR TITLE
Add Options and Head objects to the RequestBuilding trait

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
@@ -45,11 +45,13 @@ trait RequestBuilding {
     }
   }
 
-  object Get    extends RequestBuilder { def method = GET }
-  object Post   extends RequestBuilder { def method = POST }
-  object Put    extends RequestBuilder { def method = PUT }
-  object Patch  extends RequestBuilder { def method = PATCH }
-  object Delete extends RequestBuilder { def method = DELETE }
+  object Get     extends RequestBuilder { def method = GET }
+  object Post    extends RequestBuilder { def method = POST }
+  object Put     extends RequestBuilder { def method = PUT }
+  object Patch   extends RequestBuilder { def method = PATCH }
+  object Delete  extends RequestBuilder { def method = DELETE }
+  object Options extends RequestBuilder { def method = OPTIONS }
+  object Head    extends RequestBuilder { def method = HEAD }
 
   def encode(encoder: Encoder): RequestTransformer = encoder.encode(_)
 

--- a/spray-httpx/src/test/scala/spray/httpx/RequestBuildingSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/RequestBuildingSpec.scala
@@ -27,6 +27,8 @@ class RequestBuildingSpec extends Specification with RequestBuilding {
   "The RequestBuilding trait" should {
     "construct simple requests" >> {
       Get() === HttpRequest()
+      Options() === HttpRequest(OPTIONS)
+      Head() === HttpRequest(HEAD)
       Post("/abc") === HttpRequest(POST, "/abc")
       Patch("/abc", "content") === HttpRequest(PATCH, "/abc", entity = "content")
       Put("/abc", Some("content")) === HttpRequest(PUT, "/abc", entity = "content")


### PR DESCRIPTION
Hi,

I was trying to test my Options route and I figured out that the Options and Head objects were missing from the RequestBuilding trait.

So here they are (with a small test).

Cheers,
Vincent
