### PR TITLE
play-json basic support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -88,7 +88,7 @@ object Build extends Build with DocSupport {
     )): _*)
     .settings(libraryDependencies ++=
       compile(mimepull) ++
-      provided(akkaActor, sprayJson, twirlApi, liftJson, json4sNative, json4sJackson) ++
+      provided(akkaActor, sprayJson, twirlApi, liftJson, json4sNative, json4sJackson, playJson) ++
       test(specs2)
     )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ import sbt._
 object Dependencies {
 
   val resolutionRepos = Seq(
-    "spray repo" at "http://repo.spray.io/"
+    "spray repo" at "http://repo.spray.io/",
+    "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
   )
 
   def compile   (deps: ModuleID*): Seq[ModuleID] = deps map (_ % "compile")
@@ -30,4 +31,6 @@ object Dependencies {
   val liftJson      = "net.liftweb"                             %%  "lift-json"                   % "2.5.1"
   val json4sNative  = "org.json4s"                              %%  "json4s-native"               % "3.2.4"
   val json4sJackson = "org.json4s"                              %%  "json4s-jackson"              % "3.2.4"
+  val playJson      = "com.typesafe.play"                       %%  "play-json"                   % "2.2.0"
 }
+

--- a/spray-httpx/src/main/scala/spray/httpx/PlayJsonSupport.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/PlayJsonSupport.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2011-2013 spray.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spray.httpx
+
+import play.api.libs.json._
+import play.api.libs.functional._
+import spray.httpx.marshalling.Marshaller
+import scala.util.control.Exception.catching
+import scala.util.control.NonFatal
+import spray.httpx.unmarshalling.{ Deserialized, MalformedContent, SimpleUnmarshaller, Unmarshaller }
+import spray.http._
+import MediaTypes._
+
+/**
+ * A trait providing automatic to and from JSON marshalling/unmarshalling using in-scope *play-json* Reads/Writes.
+ * Note that *spray-httpx* does not have an automatic dependency on *play-json*.
+ * You'll need to provide the appropriate *play-json* artifacts yourself.
+ */
+trait PlayJsonSupport {
+  implicit def playJsonUnmarshaller[T: Reads] =
+    delegate[String, T](`application/json`)(string ⇒
+      try {
+        implicitly[Reads[T]].reads(Json.parse(string)).asEither.left.map(e ⇒ MalformedContent(s"Received JSON is not valid.\n${Json.prettyPrint(JsError.toFlatJson(e))}"))
+      } catch {
+        case NonFatal(exc) ⇒ Left(MalformedContent(exc.getMessage, exc))
+      })(UTF8StringUnmarshaller)
+
+  implicit def playJsonMarshaller[T: Writes](implicit printer: JsValue ⇒ String = Json.stringify) =
+    Marshaller.delegate[T, String](ContentTypes.`application/json`) { value ⇒
+      printer(implicitly[Writes[T]].writes(value))
+    }
+
+  //
+  private val UTF8StringUnmarshaller = new Unmarshaller[String] {
+    def apply(entity: HttpEntity) = Right(entity.asString(defaultCharset = HttpCharsets.`UTF-8`))
+  }
+
+  // Unmarshaller.delegate is used as a kind of map operation; play-json JsResult can contain either validation errors or the JsValue
+  // representing a JSON object. We need a delegate method that works as a flatMap and let the provided A ⇒ Deserialized[B] function
+  // to deal with any possible error, including exceptions.
+  //
+  private def delegate[A, B](unmarshalFrom: ContentTypeRange*)(f: A ⇒ Deserialized[B])(implicit ma: Unmarshaller[A]): Unmarshaller[B] =
+    new SimpleUnmarshaller[B] {
+      val canUnmarshalFrom = unmarshalFrom
+      def unmarshal(entity: HttpEntity) = ma(entity).right.flatMap(a ⇒ f(a))
+    }
+}
+
+object PlayJsonSupport extends PlayJsonSupport

--- a/spray-httpx/src/test/scala/spray/httpx/JsonSupportSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/JsonSupportSpec.scala
@@ -2,6 +2,7 @@ package spray.httpx
 
 import org.specs2.mutable.Specification
 import org.json4s.DefaultFormats
+import play.api.libs.json.Json
 import spray.httpx.unmarshalling._
 import spray.httpx.marshalling._
 import spray.json._
@@ -87,6 +88,23 @@ class LiftJsonSupportSpec extends Specification with LiftJsonSupport {
       HttpEntity(ContentTypes.`application/json`, Employee.json).as[Employee] === Right(Employee.simple)
     }
     "provide marshalling support for a case class" in {
+      marshal(Employee.simple) === Right(HttpEntity(ContentTypes.`application/json`, Employee.json))
+    }
+    "use UTF-8 as the default charset for JSON source decoding" in {
+      HttpEntity(MediaTypes.`application/json`, Employee.utf8json).as[Employee] === Right(Employee.utf8)
+    }
+  }
+}
+
+class PlayJsonSupportSpec extends Specification with PlayJsonSupport {
+  implicit val employeeReader = Json.reads[Employee]
+  implicit val employeeWriter = Json.writes[Employee]
+
+  "The PlayJsonSupport" should {
+    "provide unmarshalling capability for case classes with an in-scope Reads[T]" in {
+      HttpEntity(ContentTypes.`application/json`, Employee.json).as[Employee] === Right(Employee.simple)
+    }
+    "provide marshalling capability for case classes with an in-scope Writes[T]" in {
       marshal(Employee.simple) === Right(HttpEntity(ContentTypes.`application/json`, Employee.json))
     }
     "use UTF-8 as the default charset for JSON source decoding" in {


### PR DESCRIPTION
Uses play-json 2.2-SNAPSHOT from the respositories hosted by Pascal Voitot (http://mandubian.com/2013/02/21/play-json-stand-alone/)

I have created a new Unmarshaller.delegate implementation that accepts a f: A => Deserialized[B]; it's located at PlayJsonUnmarshaller object inside PlayJsonSupport trait. That allowed me to return play-json validation errors as Left.

The validation errors are returned a JSON string representation, I'm still not happy with that but was better than returning a plain error string.
