### PR TITLE
spray-can-client: Usage hostname presented in url instead from remoteAddress, because remoteAddress.getHostName may be cached in httpConnections pool

### DIFF
--- a/spray-can/src/main/scala/spray/can/rendering/RequestRenderer.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RequestRenderer.scala
@@ -57,7 +57,7 @@ class RequestRenderer(userAgentHeader: String, requestSizeHint: Int) {
     put(method.value).put(' ').put(uriWithoutFragment.toString).put(' ').put(protocol.value).put(CrLf)
     val hostHeaderPresent = putHeadersAndReturnHostHeaderPresent(headers, !request.entity.isEmpty)
     if (!hostHeaderPresent) {
-      put("Host: ").put(remoteAddress.getHostName)
+      put("Host: ").put(uri.authority.host.toOption.map(_.toString).getOrElse(remoteAddress.getHostName))
       val port = remoteAddress.getPort
       if (port != 0) put(':').put(Integer.toString(port))
       put(CrLf)


### PR DESCRIPTION
``` scala
sendReceive.apply(HttpRequest(
  uri = "http://front.kulikov.demo/front.css"
)) foreach (x ⇒ println("\n\n" + x))

Thread.sleep(300)

sendReceive.apply(HttpRequest(
  uri = "http://worker.kulikov.demo/doer.css"
)) foreach (x ⇒ println("\n\n" + x))
```

front.kulikov.demo and worker.kulikov.demo both on one ip — 127.0.0.1

And second request failed with 404 File not found, because request will be sent on front.kulikov.demo host (given form cached remoteAddress from first connection)

```
GET http://worker.kulikov.demo/doer.css HTTP 1.1
...
Host: front.kulikov.demo
```
