### PR TITLE
= travis: limit parallelism for resource intensive compilation to 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 script: 
-  - sbt ++$TRAVIS_SCALA_VERSION compile test:compile
+  - sbt ++$TRAVIS_SCALA_VERSION 'set concurrentRestrictions in Global += Tags.limit(Tags.Compile, 2)' compile test:compile
   - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=1.5 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)' test
 scala:
   - 2.10.1


### PR DESCRIPTION
Hopefully this should help to get rid of SIGSEVs during the build.

At least for the first two builds on travis no sigsevs occured.
