### PR TITLE
= Fix bug where custom ClientSSLEngineProvider is not propagated to HttpHostConnectionSlot

### DIFF
--- a/spray-can/src/main/scala/spray/can/Http.scala
+++ b/spray-can/src/main/scala/spray/can/Http.scala
@@ -55,7 +55,7 @@ object Http extends ExtensionKey[HttpExt] {
 
   case class HostConnectorSetup(remoteAddress: InetSocketAddress,
                                 options: immutable.Traversable[Inet.SocketOption],
-                                settings: Option[HostConnectorSettings])(implicit sslEngineProvider: ClientSSLEngineProvider) extends Command {
+                                settings: Option[HostConnectorSettings])(implicit val sslEngineProvider: ClientSSLEngineProvider) extends Command {
     private[can] def normalized(implicit refFactory: ActorRefFactory) =
       if (settings.isDefined) this
       else copy(settings = Some(HostConnectorSettings(actorSystem)))
@@ -65,7 +65,7 @@ object Http extends ExtensionKey[HttpExt] {
               settings: Option[HostConnectorSettings] = None)(implicit sslEngineProvider: ClientSSLEngineProvider): HostConnectorSetup =
       apply(new InetSocketAddress(host, port), options, settings)
 
-    def apply(host: String, port: Int, sslEncryption: Boolean)(implicit refFactory: ActorRefFactory): HostConnectorSetup = {
+    def apply(host: String, port: Int, sslEncryption: Boolean)(implicit refFactory: ActorRefFactory, sslEngineProvider: ClientSSLEngineProvider): HostConnectorSetup = {
       val connectionSettings = ClientConnectionSettings(actorSystem).copy(sslEncryption = sslEncryption)
       apply(host, port, settings = Some(HostConnectorSettings(actorSystem).copy(connectionSettings = connectionSettings)))
     }

--- a/spray-can/src/main/scala/spray/can/client/HttpHostConnector.scala
+++ b/spray-can/src/main/scala/spray/can/client/HttpHostConnector.scala
@@ -19,11 +19,10 @@ package spray.can.client
 import scala.collection.immutable.Queue
 import akka.actor._
 import spray.util.SprayActorLogging
-import spray.io.ClientSSLEngineProvider
 import spray.http.{ HttpHeaders, HttpRequest }
 import spray.can.Http
 
-private[can] class HttpHostConnector(normalizedSetup: Http.HostConnectorSetup, clientConnectionSettingsGroup: ActorRef)(implicit sslEngineProvider: ClientSSLEngineProvider)
+private[can] class HttpHostConnector(normalizedSetup: Http.HostConnectorSetup, clientConnectionSettingsGroup: ActorRef)
     extends Actor with SprayActorLogging {
 
   import HttpHostConnector._


### PR DESCRIPTION
While experimenting with 1.1-M8 on Scala 2.10.1, I was not able to get a custom ClientSSLEngineProvider working. I was using a ClientSSLEngineProvider backed by an SSLContext with a custom TrustManager and when performing HTTPS requests, Spray was using the default SSLContext. This behavior occurred when using Http.Connect with an explicit ClientSSLEngineProvider and when using Http.HostConnectorSetup.

Through trial and error, I've determined that this PR fixes the issue but I'm not sure why. Note that the sslEngineProvider must be passed explicitly in both HttpManager and HttpHostConnector. Otherwise, the default ClientSSLEngineProvider is passed. As far as I can tell, this shouldn't be necessary because there is an implicit in scope in both cases.

I'm providing this PR as an example as to what fixed the problem - not as a production quality fix. I suspect there may be something else going on that needs the attention of one of the core spray developers. I'm not sure where to add tests for this either.
