### PR TITLE
Back pressure optimizations

### DIFF
--- a/spray-io-tests/src/test/scala/spray/io/BackPressureHandlingSpec.scala
+++ b/spray-io-tests/src/test/scala/spray/io/BackPressureHandlingSpec.scala
@@ -354,7 +354,27 @@ class BackPressureHandlingSpec extends Specification with Specs2PipelineStageTes
 
       events.expectNoMsg()
     }
+    "don't report Ack on the pipeline when Write after successful Ack fails" in new Fixture(stage) {
+      connectionActor ! write
+      commands.expectMsg(NoAckedWrite(0))
 
+      connectionActor ! write
+      commands.expectMsg(NoAckedWrite(1))
+
+      connectionActor ! write
+      commands.expectMsg(NoAckedWrite(2))
+
+      connectionActor ! write
+      commands.expectMsg(AckedWrite(3))
+
+      connectionActor ! write
+      commands.expectMsg(NoAckedWrite(4))
+
+      connectionActor ! Tcp.CommandFailed(NoAckedWrite(4))
+      connectionActor ! ack(3)
+
+      events.expectNoMsg()
+    }
     // FIXME: these cases are not yet handled
     "what happens if WriteFile fails" in pending
   }


### PR DESCRIPTION
Three things:
- don't use Queue.length but keep track of length explicitly
- reorder match to move more likely matches to the front
- make sure internal Acks don't slip into the pipeline
