### PR TITLE
Servlet 3.1 support

### DIFF
--- a/examples/spray-servlet/simple-spray-servlet31-server/src/main/resources/application.conf
+++ b/examples/spray-servlet/simple-spray-servlet31-server/src/main/resources/application.conf
@@ -1,0 +1,10 @@
+akka {
+  loglevel = INFO
+  event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+}
+
+# check the reference.conf in /spray-servlet/main/resources for all defined settings
+spray.servlet {
+  boot-class = "spray.examples.Boot"
+  request-timeout = 6s
+}

--- a/examples/spray-servlet/simple-spray-servlet31-server/src/main/resources/logback.xml
+++ b/examples/spray-servlet/simple-spray-servlet31-server/src/main/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date{MM/dd HH:mm:ss} %-5level[%thread] %logger{1} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>akka.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%date{MM/dd HH:mm:ss} %-5level[%thread] %logger{1} - %msg%n</pattern>
+        </encoder>
+    </appender> -->
+
+    <logger name="akka" level="INFO" />
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/Boot.scala
+++ b/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/Boot.scala
@@ -1,0 +1,19 @@
+package com.lucho
+
+import spray.servlet.WebBoot
+import akka.actor.{ActorSystem, Props}
+import spray.examples.DemoService
+
+class Boot extends WebBoot {
+
+  // we need an ActorSystem to host our application in
+  val system = ActorSystem("example")
+
+  // the service actor replies to incoming HttpRequests
+  val serviceActor = system.actorOf(Props[DemoService])
+
+  system.registerOnTermination {
+    // put additional cleanup code here
+    system.log.info("Application shut down")
+  }
+}

--- a/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/DemoService.scala
+++ b/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/DemoService.scala
@@ -1,0 +1,98 @@
+package spray.examples
+
+import scala.concurrent.duration._
+import akka.io.Tcp
+import akka.actor._
+import spray.util._
+import spray.http._
+import MediaTypes._
+import HttpMethods._
+
+
+class DemoService extends Actor with SprayActorLogging {
+
+  def receive = {
+    case HttpRequest(GET, Uri.Path("/"), _, _, _) =>
+      sender ! index
+
+    case HttpRequest(GET, Uri.Path("/ping"), _, _, _) =>
+      sender ! HttpResponse(entity = "PONG!")
+
+    case HttpRequest(GET, Uri.Path("/stream"), _, _, _) =>
+      val client = sender // since the Props creator is executed asyncly we need to save the sender ref
+      context.actorOf(Props(new Streamer(client, 20)))
+
+    case HttpRequest(GET, Uri.Path("/crash"), _, _, _) =>
+      sender ! HttpResponse(entity = "About to throw an exception in the request handling actor, " +
+        "which triggers an actor restart")
+      sys.error("BOOM!")
+
+    case HttpRequest(GET, Uri.Path("/timeout"), _, _, _) =>
+      log.info("Dropping request, triggering a timeout")
+
+    case HttpRequest(GET, Uri.Path("/changetimeout"), _, _, _) =>
+      sender ! SetRequestTimeout(60.seconds)
+      log.info("Changing timeout initially set by 'spray.servlet.request-timeout' property and triggering timeout")
+
+    case HttpRequest(GET, Uri.Path("/timeout/timeout"), _, _, _) =>
+      log.info("Dropping request, triggering a timeout")
+
+    case _: HttpRequest => sender ! HttpResponse(404, "Unknown resource!")
+
+    case Timedout(HttpRequest(_, Uri.Path("/timeout/timeout"), _, _, _)) =>
+      log.info("Dropping Timeout message")
+
+    case Timedout(request: HttpRequest) =>
+      sender ! HttpResponse(500, "The " + request.method + " request to '" + request.uri + "' has timed out...")
+  }
+
+  ////////////// helpers //////////////
+
+  lazy val index = HttpResponse(
+    entity = HttpEntity(`text/html`,
+      <html>
+        <body>
+          <h1>Say hello to <i>spray-servlet</i>!</h1>
+          <p>Defined resources:</p>
+          <ul>
+            <li><a href="/ping">/ping</a></li>
+            <li><a href="/stream">/stream</a></li>
+            <li><a href="/crash">/crash</a></li>
+            <li><a href="/timeout">/timeout</a></li>
+            <li><a href="/timeout/timeout">/timeout/timeout</a></li>
+          </ul>
+        </body>
+      </html>.toString
+    )
+  )
+
+  // simple case class whose instances we use as send confirmation message for streaming chunks
+  case class Ok(remaining: Int)
+
+  class Streamer(client: ActorRef, count: Int) extends Actor with SprayActorLogging {
+    log.debug("Starting streaming response ...")
+
+    // we use the successful sending of a chunk as trigger for scheduling the next chunk
+    client ! ChunkedResponseStart(HttpResponse(entity = " " * 2048)).withAck(Ok(count))
+
+    def receive = {
+      case Ok(0) =>
+        log.info("Finalizing response stream ...")
+        client ! MessageChunk("\nStopped...")
+        client ! ChunkedMessageEnd
+        context.stop(self)
+
+      case Ok(remaining) =>
+        log.info("Sending response chunk ...")
+        import context.dispatcher
+        context.system.scheduler.scheduleOnce(100.millis) {
+          client ! MessageChunk(DateTime.now.toIsoDateTimeString + ", ").withAck(Ok(remaining - 1))
+        }
+
+      case ev: Tcp.ConnectionClosed =>
+        log.info("Canceling response stream due to {} ...", ev)
+        context.stop(self)
+    }
+  }
+
+}

--- a/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/SprayServletContainerInitializer.scala
+++ b/examples/spray-servlet/simple-spray-servlet31-server/src/main/scala/spray/examples/SprayServletContainerInitializer.scala
@@ -1,0 +1,17 @@
+package com.lucho
+
+import javax.servlet.{ServletContext, ServletContainerInitializer}
+import java.util
+import spray.servlet31.Servlet31ConnectorServlet
+
+class SprayServletContainerInitializer extends ServletContainerInitializer {
+
+  def onStartup(c: util.Set[Class[_]], ctx: ServletContext) {
+    ctx.addListener("spray.servlet.Initializer")
+    val sprayServlet = ctx.addServlet("SprayConnectorServlet", classOf[Servlet31ConnectorServlet])
+    sprayServlet.setAsyncSupported(true)
+    sprayServlet.addMapping("/*")
+    sprayServlet.setLoadOnStartup(1)
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -119,7 +119,7 @@ object Build extends Build with DocSupport {
       sprayIO) // for access to akka.io.Tcp, can go away after upgrade to Akka 2.2
     .settings(sprayModuleSettings: _*)
     .settings(libraryDependencies ++=
-      provided(akkaActor, servlet30) ++
+      provided(akkaActor, servlet31) ++
       test(specs2)
     )
 
@@ -256,6 +256,7 @@ object Build extends Build with DocSupport {
 
   lazy val sprayServletExamples = Project("spray-servlet-examples", file("examples/spray-servlet"))
     .aggregate(simpleSprayServletServer)
+    .aggregate(simpleSprayServlet31Server)
     .settings(exampleSettings: _*)
 
   lazy val simpleSprayServletServer = Project("simple-spray-servlet-server",
@@ -269,4 +270,17 @@ object Build extends Build with DocSupport {
       runtime(akkaSlf4j, logback) ++
       container(jettyWebApp, servlet30)
     )
+
+  lazy val simpleSprayServlet31Server = Project("simple-spray-servlet31-server",
+    file("examples/spray-servlet/simple-spray-servlet31-server"))
+    .dependsOn(sprayHttp, sprayServlet,
+    sprayIO) // for access to akka.io.Tcp, can go away after upgrade to Akka 2.2
+    //.settings(jettyExampleSettings: _*)
+    .settings(exampleSettings: _*)
+    .settings(libraryDependencies ++=
+    compile(akkaActor) ++
+      runtime(akkaSlf4j, logback) ++
+      provided(servlet31)
+  )
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,7 @@ object Dependencies {
   val clHashMap     = "com.googlecode.concurrentlinkedhashmap"  %   "concurrentlinkedhashmap-lru" % "1.3.2"
   val jettyWebApp   = "org.eclipse.jetty"                       %   "jetty-webapp"                % "8.1.10.v20130312"
   val servlet30     = "org.eclipse.jetty.orbit"                 %   "javax.servlet"               % "3.0.0.v201112011016" artifacts Artifact("javax.servlet", "jar", "jar")
+  val servlet31     = "javax.servlet"                           %   "javax.servlet-api"           % "3.1.0"
   val logback       = "ch.qos.logback"                          %   "logback-classic"             % "1.0.12"
   val mimepull      = "org.jvnet.mimepull"                      %   "mimepull"                    % "1.9.2"
   val liftJson      = "net.liftweb"                             %%  "lift-json"                   % "2.5-RC5"

--- a/spray-servlet/src/main/scala/spray/servlet31/ModelConverter.scala
+++ b/spray-servlet/src/main/scala/spray/servlet31/ModelConverter.scala
@@ -1,0 +1,206 @@
+package spray.servlet31
+
+import java.io.{ ByteArrayOutputStream, IOException }
+import javax.servlet.http.HttpServletRequest
+import scala.collection.JavaConverters._
+import akka.event.LoggingAdapter
+import spray.http.parser.HttpParser
+import spray.http._
+import HttpHeaders._
+import StatusCodes._
+import javax.servlet.{ ServletInputStream, ReadListener }
+import spray.servlet.ConnectorSettings
+import scala.concurrent.{ Promise, Future }
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Similar to the one from Spray Servlet 3.0, but using {@link javax.servlet.ReadListener}.
+ * If content-length is known, will build an Array[Byte]. Else, a ByteArrayOutputStream.
+ */
+private[servlet31] object ModelConverter {
+
+  /**
+   * Parse request headers and hooks to read listener.
+   * @param hsRequest servlet request.
+   * @param settings spray servlet connection settings.
+   * @param log facade to log events.
+   * @return a Future that will be complete once the request body has been read.
+   */
+  def toHttpRequest(hsRequest: HttpServletRequest)(implicit settings: ConnectorSettings, log: LoggingAdapter): Future[HttpRequest] = {
+    val rawHeaders = hsRequest.getHeaderNames.asScala.map { name ⇒
+      RawHeader(name, hsRequest.getHeaders(name).asScala mkString ", ")
+    }.toList
+    val (errors, parsedHeaders) = HttpParser.parseHeaders(rawHeaders)
+    if (!errors.isEmpty) errors.foreach(e ⇒ log.warning(e.formatPretty))
+    val (contentType, contentLength) = parsedHeaders.foldLeft[(Option[ContentType], Option[Int])](None -> None) {
+      case ((None, cl), `Content-Type`(ct))   ⇒ Some(ct) -> cl
+      case ((ct, None), `Content-Length`(cl)) ⇒ ct -> Some(cl)
+      case (result, _)                        ⇒ result
+    }
+
+    if (contentLength.fold(false)(_ > settings.maxContentLength))
+      throw new IllegalRequestException(RequestEntityTooLarge, ErrorInfo("HTTP message Content-Length " +
+        contentLength.get + " exceeds the configured limit of " + settings.maxContentLength))
+
+    val promise = Promise[HttpRequest]()
+    val inputStream = hsRequest.getInputStream
+    val readListener = new ReadListener {
+
+      val buffer = if (contentLength.fold(false)(_ > 0))
+        new StaticBuffer(contentLength.get) else new DynamicBuffer
+
+      /**
+       * Fill buffer with input data.
+       */
+      def onDataAvailable() {
+        try {
+          buffer.fill(inputStream)
+        } catch {
+          case e: RequestProcessingException ⇒ {
+            log.error(e, "Could not read request entity")
+            promise.complete(new scala.util.Failure[HttpRequest](e))
+          }
+          case e: IOException ⇒ {
+            val rpe = new RequestProcessingException(InternalServerError, "Could not read request entity")
+            log.error(e, "Could not read request entity")
+            promise.complete(new scala.util.Failure[HttpRequest](rpe))
+          }
+        }
+      }
+
+      /**
+       * Fulfill promise as success.
+       */
+      def onAllDataRead() {
+        try {
+          val request = HttpRequest(
+            method = toHttpMethod(hsRequest.getMethod),
+            uri = rebuildUri(hsRequest),
+            headers = addRemoteAddressHeader(hsRequest, rawHeaders),
+            entity = toHttpEntity(buffer.getBuffer, contentType),
+            protocol = toHttpProtocol(hsRequest.getProtocol))
+          promise.complete(new scala.util.Success(request))
+        } catch {
+          case t: Throwable ⇒ promise.complete(new scala.util.Failure[HttpRequest](t))
+        }
+      }
+
+      /**
+       * Fulfill promise as failure.
+       * @param t set the promise failure to this throwable.
+       */
+      def onError(t: Throwable) {
+        promise.complete(new scala.util.Failure[HttpRequest](t))
+      }
+    }
+    inputStream.setReadListener(readListener)
+    promise.future
+  }
+
+  /**
+   * @param name HTTP method name
+   * @return an HTTPMethod that represents the method with name "name".
+   */
+  private def toHttpMethod(name: String) =
+    HttpMethods.getForKey(name)
+      .getOrElse(throw new IllegalRequestException(MethodNotAllowed, ErrorInfo("Illegal HTTP method", name)))
+
+  def rebuildUri(hsRequest: HttpServletRequest)(implicit settings: ConnectorSettings, log: LoggingAdapter): Uri = {
+    val buffer = hsRequest.getRequestURL
+    hsRequest.getQueryString match {
+      case null ⇒
+      case x    ⇒ buffer.append('?').append(x)
+    }
+    try {
+      val uri = Uri(buffer.toString)
+      if (settings.rootPath.isEmpty) uri
+      else if (uri.path.startsWith(settings.rootPath)) uri.copy(path = uri.path.dropChars(settings.rootPathCharCount))
+      else {
+        log.warning("Received request outside of configured root-path, request uri '{}', configured root path '{}'",
+          uri, settings.rootPath)
+        uri
+      }
+    } catch {
+      case e: IllegalUriException ⇒
+        throw new IllegalRequestException(BadRequest, ErrorInfo("Illegal request URI", e.getMessage))
+    }
+  }
+
+  private def addRemoteAddressHeader(hsr: HttpServletRequest, headers: List[HttpHeader])(implicit settings: ConnectorSettings): List[HttpHeader] =
+    if (settings.remoteAddressHeader) `Remote-Address`(hsr.getRemoteAddr) :: headers
+    else headers
+
+  /**
+   * @param name HTTP protocol name
+   * @return an HTTPProtocol that represents the protocol with name "name".
+   */
+  private def toHttpProtocol(name: String) =
+    HttpProtocols.getForKey(name)
+      .getOrElse(throw new IllegalRequestException(BadRequest, ErrorInfo("Illegal HTTP protocol", name)))
+
+  private def toHttpEntity(buf: Array[Byte], contentType: Option[ContentType]): HttpEntity = {
+    if (contentType.isEmpty) HttpEntity(buf) else HttpEntity(contentType.get, buf)
+  }
+
+  /**
+   * Buffer trait to save input data from the request into memory.
+   */
+  private sealed trait Buffer {
+
+    /**
+     * Fill this buffer with data obtained from a stream.
+     * @param inputStream stream to get the data from.
+     */
+    def fill(inputStream: ServletInputStream)
+
+    /**
+     * @return the data that this buffer holds.
+     */
+    def getBuffer: Array[Byte]
+  }
+
+  /**
+   * A Buffer that holds data whose length has been preset.
+   * @param contentLength the length of the data to hold.
+   */
+  private final class StaticBuffer(contentLength: Int) extends Buffer {
+
+    val buf = new Array[Byte](contentLength)
+
+    var bytesRead: AtomicInteger = new AtomicInteger(0)
+
+    def fill(inputStream: ServletInputStream) {
+      var bytesReadInt = bytesRead.get()
+      while (inputStream.isReady) {
+        buf(bytesRead.get) = inputStream.read().toByte
+        bytesReadInt = bytesReadInt + 1
+        if (bytesReadInt > contentLength) {
+          inputStream.close()
+          val e = new RequestProcessingException(InternalServerError, "Illegal Servlet request entity, " +
+            "expected length " + contentLength + " but only has length " + bytesReadInt)
+          throw e
+        } else {
+          bytesRead.set(bytesReadInt)
+        }
+      }
+    }
+
+    def getBuffer = buf
+  }
+
+  /**
+   * A Buffer that grows on demand to hold data.
+   */
+  private final class DynamicBuffer extends Buffer {
+
+    val baos = new ByteArrayOutputStream()
+
+    def fill(inputStream: ServletInputStream) {
+      while (inputStream.isReady) {
+        baos.write(inputStream.read())
+      }
+    }
+
+    def getBuffer = baos.toByteArray
+  }
+}

--- a/spray-servlet/src/main/scala/spray/servlet31/Responder.scala
+++ b/spray-servlet/src/main/scala/spray/servlet31/Responder.scala
@@ -1,0 +1,344 @@
+package spray.servlet31
+
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+import javax.servlet.{ WriteListener, AsyncContext }
+import scala.concurrent.duration.Duration
+import akka.io.Tcp
+import spray.http._
+import akka.actor.{ ActorSystem, ActorRef }
+import java.io.{ ByteArrayInputStream, IOException }
+import javax.servlet.http.HttpServletResponse
+import akka.spray.UnregisteredActorRef
+import scala.util.control.NonFatal
+import akka.event.LoggingAdapter
+import spray.servlet.ConnectorSettings
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.concurrent.Future
+import scala.util.Try
+import scala.util.Failure
+import spray.http.ChunkedResponseStart
+import akka.actor.UnhandledMessage
+import spray.http.HttpResponse
+import scala.util.Success
+import spray.http.HttpRequest
+import spray.http.SetTimeoutTimeout
+import spray.http.Timedout
+import spray.http.SetRequestTimeout
+
+/**
+ * Actor that handles writing to the response stream, hooking to {@link javax.servlet.WriteListener }
+ * @param system actorSystem that will contain this actor.
+ * @param log facade to log events.
+ * @param settings spray servlet connection settings.
+ * @param asyncContext context to obtain the response OutputStream.
+ * @param requestString friendly string that represents the request. Used for logging.
+ * @param futureRequest Once completed, will hold the request data (or a failure)
+ * @param serviceActor spray routing to pass the request (once completed) and wait for any response.
+ */
+private[servlet31] class Responder(system: ActorSystem, log: LoggingAdapter, settings: ConnectorSettings,
+                                   asyncContext: AsyncContext, requestString: String, futureRequest: Future[HttpRequest],
+                                   serviceActor: ActorRef) extends UnregisteredActorRef(system) {
+
+  // Constants and mutable state used when dealing with chunks of data. Copied from Spray Servlet 3.0
+  final val OPEN = 0
+  final val STARTED = 1
+  final val COMPLETED = 2
+  val state = new AtomicInteger(OPEN)
+
+  /**
+   * Will contain the request once its future is completed. Maybe it should be Atomic.
+   */
+  private var theRequest: Option[HttpRequest] = None
+
+  /**
+   * @return a friendly string that represents the request. Used for logging.
+   */
+  private def requestStringForLog: String = theRequest.map(_.toString).getOrElse(requestString)
+
+  private val queue: ConcurrentLinkedQueue[(ByteArrayInputStream, PostProcessMessage, String)] =
+    new ConcurrentLinkedQueue[(ByteArrayInputStream, PostProcessMessage, String)]
+
+  /**
+   * The first time data arrives and the queue is filled with something,
+   * we hook the listener so it can start moving data from the queue to the OutputStream
+   * whenever the Servlet Container wants.
+   */
+  private val writeListenerSet = new AtomicBoolean(false)
+
+  /**
+   * Servlet response.
+   */
+  private val hsResponse = asyncContext.getResponse.asInstanceOf[HttpServletResponse]
+
+  /**
+   * Servlet 3.1 Write Listener
+   */
+  private val writeListener = new WriteListener {
+
+    /**
+     * Log the error event.
+     * @param t the error that occured.
+     */
+    def onError(t: Throwable) {
+      log.error(t, "Error during async processing of {}", requestStringForLog)
+    }
+
+    /**
+     * Will be called by the servlet container. The first time, it will extract the data from the request and
+     * pass it to spray routing.
+     */
+    def onWritePossible() {
+      tryWriteFromQueue()
+    }
+  }
+
+  futureRequest.onComplete(processRequestFromFuture)(system.dispatcher)
+
+  /**
+   * The timeout duration can vary with a call to SetTimeout
+   */
+  private var timeoutTimeout: Duration = settings.timeoutTimeout
+
+  /**
+   * Helper method to handle null strings.
+   * @param s a possibly null String.
+   * @return s or an empty String if s is null.
+   */
+  private def nullAsEmpty(s: String): String = if (s == null) "" else s
+
+  private def processRequestFromFuture(successOrFailure: Try[HttpRequest]) {
+    successOrFailure match {
+      case Success(request: HttpRequest) ⇒ {
+        theRequest = Some(request)
+        serviceActor.tell(request, this)
+      }
+      case Failure(t: Throwable) ⇒ t match {
+        case e: IllegalRequestException ⇒ {
+          log.warning("Illegal request {}\n\t{}\n\tCompleting with '{}' response",
+            requestStringForLog, e.info.formatPretty, e.status)
+          writeResponse(HttpResponse(e.status, e.info.format(settings.verboseErrorMessages)), PostProcessMessage(close = true))
+        }
+        case e: RequestProcessingException ⇒ {
+          log.warning("Request {} could not be handled normally\n\t{}\n\tCompleting with '{}' response",
+            requestStringForLog, e.info.formatPretty, e.status)
+          writeResponse(HttpResponse(e.status, e.info.format(settings.verboseErrorMessages)), PostProcessMessage(close = true))
+        }
+        case NonFatal(e) ⇒ {
+          log.error(e, "Error during processing of request {}", requestStringForLog)
+          writeResponse(HttpResponse(500, entity = "The request could not be handled"), PostProcessMessage(close = true))
+        }
+      }
+
+    }
+  }
+
+  /**
+   * If there is data in the queue, try to write it to the response OutputStream, while it's ready.
+   */
+  private def tryWriteFromQueue() {
+    if (!queue.isEmpty) {
+      val (byteInputStream, postProcessMessage, responseAsStringForLog) = queue.peek()
+      val tryToWrite: Try[Unit] = Try {
+        while (hsResponse.getOutputStream.isReady && byteInputStream.available > 0) {
+          hsResponse.getOutputStream.write(byteInputStream.read())
+        }
+      }
+      tryToWrite match {
+        case Success(_) ⇒
+        case Failure(e) ⇒ e match {
+          case ioe: IOException ⇒
+            log.error("Could not write response body, probably the request has either timed out or the client has " +
+              "disconnected\nRequest: {}\nResponse: {}\nError: {}",
+              requestStringForLog, responseAsStringForLog, ioe)
+          case another ⇒
+            log.error("Could not complete request\nRequest: {}\nResponse: {}\nError: {}",
+              requestStringForLog, responseAsStringForLog, another)
+        }
+      }
+      //val error: Option[Throwable] = (tryToWrite map {case _ => None} recover { case t => Some(t)}).toOption.flatten
+
+      if (tryToWrite.isFailure || byteInputStream.available() == 0) {
+        queue.poll()
+        postProcess(tryToWrite, postProcessMessage)
+      }
+    }
+  }
+
+  /**
+   * Defines what to do after some data has been written to the stream.
+   * @param ack if something, send it back to the sender.
+   * @param close if true, close the stream (complete) and tell the sender that we are closed.
+   * @param sender the actor that sent us the data.
+   */
+  private case class PostProcessMessage(close: Boolean, sender: Option[ActorRef] = None, ack: Option[Any] = None)
+
+  private def postProcess(error: Try[_], postProcessMessage: PostProcessMessage) {
+    error match {
+      case Success(_) ⇒ {
+        postProcessMessage.ack.foreach(ack ⇒ postProcessMessage.sender.foreach(sender ⇒ sender.tell(ack, this)))
+        if (postProcessMessage.close) {
+          asyncContext.complete()
+          if (postProcessMessage.sender.isDefined) {
+            postProcessMessage.sender.get.tell(Tcp.Closed, this)
+          }
+        }
+      }
+      case Failure(e) ⇒ {
+        asyncContext.complete()
+        if (postProcessMessage.sender.isDefined) {
+          postProcessMessage.sender.get.tell(Tcp.ErrorClosed(nullAsEmpty(e.getMessage)), this)
+        }
+      }
+    }
+  }
+
+  /**
+   * Method to handle messages that this Actor receives.
+   * @param message an actor message.
+   * @param sender the actor that sent the message.
+   */
+  def handle(message: Any)(implicit sender: ActorRef) {
+    val trueSender = sender
+    message match {
+      case wrapper: HttpMessagePartWrapper if wrapper.messagePart.isInstanceOf[HttpResponsePart] ⇒
+        wrapper.messagePart.asInstanceOf[HttpResponsePart] match {
+          case response: HttpResponse ⇒
+            if (state.compareAndSet(OPEN, COMPLETED)) {
+              writeResponse(response, PostProcessMessage(close = true, Some(trueSender), wrapper.ack))
+            } else state.get match {
+              case STARTED ⇒
+                log.warning("Received an HttpResponse after a ChunkedResponseStart, dropping ...\nRequest: {}\nResponse: {}", requestStringForLog, response)
+              case COMPLETED ⇒
+                log.warning("Received a second response for a request that was already completed, dropping ...\nRequest: {}\nResponse: {}", requestStringForLog, response)
+            }
+
+          case response: ChunkedResponseStart ⇒
+            if (state.compareAndSet(OPEN, STARTED)) {
+              writeResponse(response, PostProcessMessage(close = false, Some(trueSender), wrapper.ack))
+            } else state.get match {
+              case STARTED ⇒
+                log.warning("Received a second ChunkedResponseStart, dropping ...\nRequest: {}\nResponse: {}", requestStringForLog, response)
+              case COMPLETED ⇒
+                log.warning("Received a ChunkedResponseStart for a request that was already completed, dropping ...\nRequest: {}\nResponse: {}", requestStringForLog, response)
+            }
+
+          case MessageChunk(body, _) ⇒ state.get match {
+            case OPEN ⇒
+              log.warning("Received a MessageChunk before a ChunkedResponseStart, dropping ...\nRequest: {}\nChunk: {} bytes\n", requestStringForLog, body.length)
+            case STARTED ⇒
+              writeChunk(body, PostProcessMessage(close = false, Some(trueSender), wrapper.ack))
+            case COMPLETED ⇒
+              log.warning("Received a MessageChunk for a request that was already completed, dropping ...\nRequest: {}\nChunk: {} bytes", requestStringForLog, body.length)
+          }
+
+          case _: ChunkedMessageEnd ⇒
+            if (state.compareAndSet(STARTED, COMPLETED)) {
+              postProcess(Success(), PostProcessMessage(close = true, Some(trueSender), wrapper.ack))
+            } else state.get match {
+              case OPEN ⇒
+                log.warning("Received a ChunkedMessageEnd before a ChunkedResponseStart, dropping ...\nRequest: {}", requestStringForLog)
+              case COMPLETED ⇒
+                log.warning("Received a ChunkedMessageEnd for a request that was already completed, dropping ...\nRequest: {}", requestStringForLog)
+            }
+        }
+
+      case msg @ SetRequestTimeout(timeout) ⇒
+        state.get match {
+          case COMPLETED ⇒ notCompleted(msg)
+          case _ ⇒
+            val millis = if (timeout.isFinite()) timeout.toMillis else 0
+            asyncContext.setTimeout(millis)
+        }
+
+      case msg @ SetTimeoutTimeout(timeout) ⇒
+        state.get match {
+          case COMPLETED ⇒ notCompleted(msg)
+          case _         ⇒ timeoutTimeout = timeout
+        }
+
+      case x ⇒ system.eventStream.publish(UnhandledMessage(x, sender, this))
+    }
+  }
+
+  /**
+   * Log that a message came but the response was already committed.
+   * @param msg the unwanted message.
+   */
+  private def notCompleted(msg: Any) {
+    log.warning("Received a {} for a request that was already completed, dropping ...\nRequest: {}",
+      msg, requestStringForLog)
+  }
+
+  /**
+   * Write a chunk of data to the queue, and maybe to the OutputStream if it's ready.
+   * @param buffer data
+   * @param postProcessMessage defines what to do after the data is sent to the stream.
+   */
+  private def writeChunk(buffer: Array[Byte], postProcessMessage: PostProcessMessage) {
+    queue.add((new ByteArrayInputStream(buffer), postProcessMessage, hsResponse.toString))
+    tryWriteFromQueue()
+  }
+
+  private def writeResponse(response: HttpMessageStart with HttpResponsePart,
+                            postProcessMessage: PostProcessMessage) {
+
+    val resp = response.message.asInstanceOf[HttpResponse]
+    hsResponse.setStatus(resp.status.intValue)
+    resp.headers.foreach {
+      header ⇒
+        header.lowercaseName match {
+          case "content-type"   ⇒ // we never render these headers here, because their production is the
+          case "content-length" ⇒ // responsibility of the spray-servlet layer, not the user
+          case _                ⇒ hsResponse.addHeader(header.name, header.value)
+        }
+    }
+    resp.entity match {
+      case EmptyEntity ⇒ {
+        postProcess(Success(), postProcessMessage)
+      }
+      case HttpBody(contentType, buffer) ⇒ {
+        hsResponse.addHeader("Content-Type", contentType.value)
+        if (response.isInstanceOf[HttpResponse]) hsResponse.addHeader("Content-Length", buffer.length.toString)
+        queue.add((new ByteArrayInputStream(buffer), postProcessMessage, response.toString))
+
+        if (!writeListenerSet.get()) {
+          writeListenerSet.set(true)
+          hsResponse.getOutputStream.setWriteListener(writeListener)
+        } else {
+          tryWriteFromQueue()
+        }
+
+      }
+    }
+  }
+
+  /**
+   * public method to be called by AsyncListener.
+   * @param timeoutHandler actor to tell that a timeOut happened.
+   */
+  def callTimeout(timeoutHandler: ActorRef) {
+    val timeOutResponder = new UnregisteredActorRef(system) {
+      def handle(message: Any)(implicit sender: ActorRef) {
+        message match {
+          case x: HttpResponse ⇒ writeResponse(x, PostProcessMessage(close = false))
+          case x               ⇒ system.eventStream.publish(UnhandledMessage(x, sender, this))
+        }
+      }
+    }
+
+    writeResponse(timeoutResponse(), PostProcessMessage(close = false))
+    if (timeoutTimeout.isFinite() && theRequest.isDefined) {
+      timeoutHandler.tell(Timedout(theRequest.get), timeOutResponder)
+    }
+
+  }
+
+  /**
+   * @return a Timeout Response to send to the client.
+   */
+  private def timeoutResponse(): HttpResponse = HttpResponse(
+    status = 500,
+    entity = "Ooops! The server was not able to produce a timely response to your request.\n" +
+      "Please try again in a short while!")
+
+}

--- a/spray-servlet/src/main/scala/spray/servlet31/Servlet31ConnectorServlet.scala
+++ b/spray-servlet/src/main/scala/spray/servlet31/Servlet31ConnectorServlet.scala
@@ -1,0 +1,112 @@
+package spray.servlet31
+
+import spray.servlet.{ Initializer, ConnectorSettings }
+import javax.servlet.http.{ HttpServlet, HttpServletResponse, HttpServletRequest }
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.event.{ Logging, LoggingAdapter }
+import akka.spray.RefUtils
+import javax.servlet.{ AsyncEvent, AsyncListener, AsyncContext }
+
+class Servlet31ConnectorServlet extends HttpServlet {
+  var system: ActorSystem = _
+  var serviceActor: ActorRef = _
+  var timeoutHandler: ActorRef = _
+  implicit var settings: ConnectorSettings = _
+  implicit var log: LoggingAdapter = _
+
+  /**
+   * The same as Spray Servlet 3.0
+   */
+  override def init() {
+    import Initializer._
+    system = getServletContext.getAttribute(SystemAttrName).asInstanceOf[ActorSystem]
+    serviceActor = getServletContext.getAttribute(ServiceActorAttrName).asInstanceOf[ActorRef]
+    settings = getServletContext.getAttribute(SettingsAttrName).asInstanceOf[ConnectorSettings]
+    timeoutHandler = if (settings.timeoutHandler.isEmpty) serviceActor else system.actorFor(settings.timeoutHandler)
+    require(system != null, "No ActorSystem configured")
+    require(serviceActor != null, "No ServiceActor configured")
+    require(settings != null, "No ConnectorSettings configured")
+    require(RefUtils.isLocal(serviceActor), "The serviceActor must live in the same JVM as the Servlet30ConnectorServlet")
+    require(RefUtils.isLocal(timeoutHandler), "The timeoutHandler must live in the same JVM as the Servlet30ConnectorServlet")
+    log = Logging(system, this.getClass)
+    log.info("Initialized Servlet API 3.1 <=> Spray Connector")
+  }
+
+  /**
+   * Service returns quickly, to free HTTP thread pool.
+   * @param hsRequest servlet request.
+   * @param hsResponse servlet response.
+   */
+  override def service(hsRequest: HttpServletRequest, hsResponse: HttpServletResponse) {
+    def requestStringForLog: String = "%s request to '%s'" format (hsRequest.getMethod, ModelConverter.rebuildUri(hsRequest))
+    val asyncContext = hsRequest.startAsync()
+    asyncContext.setTimeout(settings.requestTimeout.toMillis)
+    asyncContext.addListener(new AsyncContextListener(asyncContext, requestStringForLog))
+  }
+
+  /**
+   * Listen to timeout and error events.
+   * @param asyncContext the context that this listener belongs to.
+   * @param requestStringForLog friendly string that represents the request. Used for logging.
+   */
+  private class AsyncContextListener(private val asyncContext: AsyncContext,
+                                     private val requestStringForLog: String) extends AsyncListener {
+
+    /**
+     * onStartAsync should be run quick enough for this to be set before a timeout.
+     */
+    var responder: Responder = null
+
+    /**
+     * A timeout happened. Functionality copied from Spray Servlet 3.0
+     * @param event timeout event data.
+     */
+    def onTimeout(event: AsyncEvent) {
+      log.warning("Timeout of {}", requestStringForLog)
+      if (responder != null) responder.callTimeout(timeoutHandler)
+      asyncContext.complete()
+    }
+
+    /**
+     * An error happened. We log it.
+     * @param event error event data.
+     */
+    def onError(event: AsyncEvent) {
+      event.getThrowable match {
+        case null ⇒ log.error("Unspecified Error during async processing of {}", requestStringForLog)
+        case ex   ⇒ log.error(ex, "Error during async processing of {}", requestStringForLog)
+      }
+    }
+
+    /**
+     * Parse request headers and hooks to read listener. Responder will take charge once read is completed.
+     * @param event startAsync event data.
+     */
+    def onStartAsync(event: AsyncEvent) {
+      val hsRequest = asyncContext.getRequest.asInstanceOf[HttpServletRequest]
+      val futureRequest = ModelConverter.toHttpRequest(hsRequest)
+      responder = new Responder(system, log, settings, asyncContext, requestStringForLog,
+        futureRequest, serviceActor)
+    }
+
+    /**
+     * We do nothing here.
+     * @param event complete event data.
+     */
+    def onComplete(event: AsyncEvent) {
+      log.debug("onComplete event of {}", requestStringForLog)
+    }
+
+  }
+
+  /**
+   * The same as Spray Servlet 3.0
+   */
+  override def destroy() {
+    if (!system.isTerminated) {
+      system.shutdown()
+      system.awaitTermination()
+    }
+  }
+
+}


### PR DESCRIPTION
[Servlet 3.1](http://jcp.org/en/jsr/detail?id=340) builds on ReadListeners and WriteListeners to provide asynchronous non-blocking I/O instead of the asynchronous traditional I/O of Servlet 3.0. See [example 1](https://blogs.oracle.com/arungupta/entry/non_blocking_i_o_using) and [example 2](https://weblogs.java.net/blog/swchan2/archive/2013/04/16/non-blocking-io-servlet-31-example).

Right now the only container that provides Servlet 3.1 support is [Glassfish 4](https://glassfish.java.net/). So the way to test this is to build a WAR file and deploy it on a Glassfish instance. Later there will be embedded Jetty or Tomcat containers. Pretty sure Tomcat 8.

And the most important deal, is it faster than asynchronous traditional I/O ? I haven't done any tests, but I don't think so. And I'm pretty sure that depends on how the container is made. I haven't checked [Glassfish source code](https://java.net/projects/glassfish/sources/svn/show) either. I have to take a look at that.

Still, I think this is a start. I have commented the code as much as I could to make its intentions clear.