### PR TITLE
= build: update to sbt 0.12.4-RC3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.3
+sbt.version=0.12.4-RC3


### PR DESCRIPTION
Performance of (cold) sbt compilation for Scala != 2.9.2 was slow. This should improve the speed of travis builds.

See https://groups.google.com/forum/#!topic/simple-build-tool/HMjm3jpHc6Y
