### PR TITLE
routing: move `UserPassAuthenticator.cached` to `CachedUserPassAuthenticator.apply`, fixes #352

### DIFF
--- a/spray-routing/src/main/scala/spray/routing/authentication/UserPassAuthenticator.scala
+++ b/spray-routing/src/main/scala/spray/routing/authentication/UserPassAuthenticator.scala
@@ -47,12 +47,14 @@ object UserPassAuthenticator {
           }
         }
       }
+}
 
+object CachedUserPassAuthenticator {
   /**
    * Creates a wrapper around an UserPassAuthenticator providing authentication lookup caching using the given cache.
    * Note that you need to manually add a dependency to the spray-caching module in order to be able to use this method.
    */
-  def cached[T](inner: UserPassAuthenticator[T], cache: Cache[Option[T]] = LruCache[Option[T]]())(implicit ec: ExecutionContext): UserPassAuthenticator[T] =
+  def apply[T](inner: UserPassAuthenticator[T], cache: Cache[Option[T]] = LruCache[Option[T]]())(implicit ec: ExecutionContext): UserPassAuthenticator[T] =
     userPassOption ⇒
       cache(userPassOption) {
         inner(userPassOption)


### PR DESCRIPTION
Because `UserPassAuthenticator.cached` relies on a spray-caching Cache even code not using this method
(but simply other `UserPassAuthenticator` methods like `apply` or `fromConfig`) must have spray-caching
on the classpath in order to avoid a `bad symbolic reference` compiler error.
This patch moves the `cached` method into a dedicated object thereby freeing up `UserPassAuthenticator`
from the dependency on the spray-caching module.
