### PR TITLE
! http: make only standard charsets available as constants, fixes #340

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpCharset.scala
+++ b/spray-http/src/main/scala/spray/http/HttpCharset.scala
@@ -61,30 +61,43 @@ object HttpCharsets extends ObjectRegistry[String, HttpCharset] {
   private def register(value: String)(aliases: String*): HttpCharset =
     register(HttpCharset(value)(aliases: _*))
 
+  private def tryRegister(value: String)(aliases: String*): Unit =
+    try register(value)(aliases: _*)
+    catch {
+      case e: java.nio.charset.UnsupportedCharsetException ⇒ // ignore
+    }
+
   // format: OFF
+  // Only those first 6 are standard charsets known to be supported on all platforms
+  // by Javadoc of java.nio.charset.Charset
+  // see http://docs.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html
   val `US-ASCII`     = register("US-ASCII")("iso-ir-6", "ANSI_X3.4-1986", "ISO_646.irv:1991", "ASCII", "ISO646-US", "us", "IBM367", "cp367", "csASCII")
   val `ISO-8859-1`   = register("ISO-8859-1")("iso-ir-100", "ISO_8859-1", "latin1", "l1", "IBM819", "CP819", "csISOLatin1")
-  val `ISO-8859-2`   = register("ISO-8859-2")("iso-ir-101", "ISO_8859-2", "latin2", "l2", "csISOLatin2")
-  val `ISO-8859-3`   = register("ISO-8859-3")("iso-ir-109", "ISO_8859-3", "latin3", "l3", "csISOLatin3")
-  val `ISO-8859-4`   = register("ISO-8859-4")("iso-ir-110", "ISO_8859-4", "latin4", "l4", "csISOLatin4")
-  val `ISO-8859-5`   = register("ISO-8859-5")("iso-ir-144", "ISO_8859-5", "cyrillic", "csISOLatinCyrillic")
-  val `ISO-8859-6`   = register("ISO-8859-6")("iso-ir-127", "ISO_8859-6", "ECMA-114", "ASMO-708", "arabic", "csISOLatinArabic")
-  val `ISO-8859-7`   = register("ISO-8859-7")("iso-ir-126", "ISO_8859-7", "ELOT_928", "ECMA-118", "greek", "greek8", "csISOLatinGreek")
-  val `ISO-8859-8`   = register("ISO-8859-8")("iso-ir-138", "ISO_8859-8", "hebrew", "csISOLatinHebrew")
-  val `ISO-8859-9`   = register("ISO-8859-9")("iso-ir-148", "ISO_8859-9", "latin5", "l5", "csISOLatin5")
-  val `ISO-8859-10`  = register("ISO-8859-1")("iso-ir-157", "l6", "ISO_8859-10", "csISOLatin6", "latin6")
   val `UTF-8`        = register("UTF-8")("UTF8")
   val `UTF-16`       = register("UTF-16")("UTF16")
   val `UTF-16BE`     = register("UTF-16BE")()
   val `UTF-16LE`     = register("UTF-16LE")()
-  val `UTF-32`       = register("UTF-32")("UTF32")
-  val `UTF-32BE`     = register("UTF-32BE")()
-  val `UTF-32LE`     = register("UTF-32LE")()
-  val `windows-1250` = register("windows-1250")("cp1250", "cp5346")
-  val `windows-1251` = register("windows-1251")("cp1251", "cp5347")
-  val `windows-1252` = register("windows-1252")("cp1252", "cp5348")
-  val `windows-1253` = register("windows-1253")("cp1253", "cp5349")
-  val `windows-1254` = register("windows-1254")("cp1254", "cp5350")
-  val `windows-1257` = register("windows-1257")("cp1257", "cp5353")
+
+  // those are not necessarily supported on every platform so we can't expose them as constants here
+  // but we try to register them so that all the aliases are registered
+  tryRegister("ISO-8859-2")("iso-ir-101", "ISO_8859-2", "latin2", "l2", "csISOLatin2")
+  tryRegister("ISO-8859-3")("iso-ir-109", "ISO_8859-3", "latin3", "l3", "csISOLatin3")
+  tryRegister("ISO-8859-4")("iso-ir-110", "ISO_8859-4", "latin4", "l4", "csISOLatin4")
+  tryRegister("ISO-8859-5")("iso-ir-144", "ISO_8859-5", "cyrillic", "csISOLatinCyrillic")
+  tryRegister("ISO-8859-6")("iso-ir-127", "ISO_8859-6", "ECMA-114", "ASMO-708", "arabic", "csISOLatinArabic")
+  tryRegister("ISO-8859-7")("iso-ir-126", "ISO_8859-7", "ELOT_928", "ECMA-118", "greek", "greek8", "csISOLatinGreek")
+  tryRegister("ISO-8859-8")("iso-ir-138", "ISO_8859-8", "hebrew", "csISOLatinHebrew")
+  tryRegister("ISO-8859-9")("iso-ir-148", "ISO_8859-9", "latin5", "l5", "csISOLatin5")
+  tryRegister("ISO-8859-10")("iso-ir-157", "l6", "ISO_8859-10", "csISOLatin6", "latin6")
+
+  tryRegister("UTF-32")("UTF32")
+  tryRegister("UTF-32BE")()
+  tryRegister("UTF-32LE")()
+  tryRegister("windows-1250")("cp1250", "cp5346")
+  tryRegister("windows-1251")("cp1251", "cp5347")
+  tryRegister("windows-1252")("cp1252", "cp5348")
+  tryRegister("windows-1253")("cp1253", "cp5349")
+  tryRegister("windows-1254")("cp1254", "cp5350")
+  tryRegister("windows-1257")("cp1257", "cp5353")
   // format: ON
 }

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -101,7 +101,7 @@ class HttpHeaderSpec extends Specification {
       "Content-Type: text/plain; charset=utf8" !
       example(`Content-Type`(ContentType(`text/plain`, `UTF-8`)), fix(_).replace("utf", "UTF-"))_ ^
       "Content-Type: text/xml; version=3; charset=windows-1252" !
-      example(`Content-Type`(ContentType(MediaType.custom("text", "xml", parameters = Map("version" -> "3")), `windows-1252`)))_ ^
+      example(`Content-Type`(ContentType(MediaType.custom("text", "xml", parameters = Map("version" -> "3")), HttpCharsets.getForKey("windows-1252"))))_ ^
       "Content-Type: text/plain; charset=fancy-pants" !
       errorExample(ErrorInfo("Illegal HTTP header 'Content-Type': Unsupported charset", "fancy-pants"))_ ^
       "Content-Type: multipart/mixed; boundary=ABC123" ! example(`Content-Type`(ContentType(new `multipart/mixed`("ABC123"))))_ ^

--- a/spray-routing-tests/src/test/scala/spray/routing/MarshallingDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/MarshallingDirectivesSpec.scala
@@ -29,7 +29,7 @@ import HttpCharsets._
 class MarshallingDirectivesSpec extends RoutingSpec {
 
   implicit val IntUnmarshaller =
-    Unmarshaller[Int](ContentTypeRange(`text/xml`, `ISO-8859-2`), `text/html`, `application/xhtml+xml`) {
+    Unmarshaller[Int](ContentTypeRange(`text/xml`, HttpCharsets.getForKey("iso-8859-2").get), `text/html`, `application/xhtml+xml`) {
       case HttpBody(_, buffer) ⇒ XML.load(new ByteArrayInputStream(buffer)).text.toInt
     }
 


### PR DESCRIPTION
Only standard charsets are known to be available on all Java platforms.
If another one was missing, initialization fatally aborted. Constants
for others charsets can still be retrieved from the registry but can't
be supplied as constants as those may not be available.

Another bug was fixed here: the 'ISO-8859-10' charset was wrongly registered
as 'ISO-8859-1'.
