### PR TITLE
! routing: redefine `PathMatchers.Empty` as `PathMatchers.Neutral` with explicit type annotation, fixes #339

### DIFF
--- a/spray-routing/src/main/scala/spray/routing/PathMatcher.scala
+++ b/spray-routing/src/main/scala/spray/routing/PathMatcher.scala
@@ -319,8 +319,9 @@ trait PathMatchers {
 
   /**
    * A PathMatcher that always matches, doesn't consume anything and extracts nothing.
+   * Serves mainly as a neutral element in PathMatcher composition.
    */
-  val Empty = PathMatcher.provide(HNil)
+  val Neutral: PathMatcher[HNil] = PathMatcher.provide(HNil)
 
   /**
    * A PathMatcher that matches if the unmatched path starts with a path segment.


### PR DESCRIPTION
`Empty` is not a good name for a PathMatcher that always matches without consuming anything, as it can easily be misunderstood as a PathMatcher for `Path.empty`. We therefore rename it here to `Neutral`.
