### PR TITLE
Render `WWW-Authenticate` header also for AuthenticationFailedRejection

### DIFF
--- a/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
@@ -21,49 +21,51 @@ import akka.event.NoLogging
 import spray.routing.authentication._
 import spray.http._
 import HttpHeaders._
+import AuthenticationFailedRejection._
 
 class SecurityDirectivesSpec extends RoutingSpec {
 
-  val dontAuth = UserPassAuthenticator[BasicUserContext](_ ⇒ Future.successful(None))
+  val dontAuth = BasicAuth(UserPassAuthenticator[BasicUserContext](_ ⇒ Future.successful(None)), "Realm")
 
-  val doAuth = UserPassAuthenticator[BasicUserContext] { userPassOption ⇒
+  val doAuth = BasicAuth(UserPassAuthenticator[BasicUserContext] { userPassOption ⇒
     Future.successful(Some(BasicUserContext(userPassOption.get.user)))
-  }
+  }, "Realm")
 
   "the 'authenticate(BasicAuth())' directive" should {
-    "reject requests without Authorization header with an AuthenticationRequiredRejection" in {
+    "reject requests without Authorization header with an AuthenticationFailedRejection" in {
       Get() ~> {
-        authenticate(BasicAuth(dontAuth, "Realm")) { echoComplete }
-      } ~> check { rejection === AuthenticationRequiredRejection("Basic", "Realm", Map.empty) }
+        authenticate(dontAuth) { echoComplete }
+      } ~> check { rejection === AuthenticationFailedRejection(CredentialsMissing, dontAuth) }
     }
-    "reject unauthenticated requests with Authorization header with an AuthorizationFailedRejection" in {
+    "reject unauthenticated requests with Authorization header with an AuthenticationFailedRejection" in {
       Get() ~> Authorization(BasicHttpCredentials("Bob", "")) ~> {
-        authenticate(BasicAuth(dontAuth, "Realm")) { echoComplete }
-      } ~> check { rejection === AuthenticationFailedRejection("Realm") }
+        authenticate(dontAuth) { echoComplete }
+      } ~> check { rejection === AuthenticationFailedRejection(CredentialsRejected, dontAuth) }
     }
     "extract the object representing the user identity created by successful authentication" in {
       Get() ~> Authorization(BasicHttpCredentials("Alice", "")) ~> {
-        authenticate(BasicAuth(doAuth, "Realm")) { echoComplete }
+        authenticate(doAuth) { echoComplete }
       } ~> check { entityAs[String] === "BasicUserContext(Alice)" }
     }
     "properly handle exceptions thrown in its inner route" in {
       object TestException extends spray.util.SingletonException
       Get() ~> Authorization(BasicHttpCredentials("Alice", "")) ~> {
         handleExceptions(ExceptionHandler.default) {
-          authenticate(BasicAuth(doAuth, "Realm")) { _ ⇒ throw TestException }
+          authenticate(doAuth) { _ ⇒ throw TestException }
         }
       } ~> check { status === StatusCodes.InternalServerError }
     }
   }
 
   "the 'authenticate(<ContextAuthenticator>)' directive" should {
+    case object AuthenticationRejection extends Rejection
+
     val myAuthenticator: ContextAuthenticator[Int] = ctx ⇒ Future {
-      Either.cond(ctx.request.uri.authority.host == Uri.NamedHost("spray.io"), 42,
-        AuthenticationRequiredRejection("my-scheme", "MyRealm", Map()))
+      Either.cond(ctx.request.uri.authority.host == Uri.NamedHost("spray.io"), 42, AuthenticationRejection)
     }
     "reject requests not satisfying the filter condition" in {
       Get() ~> authenticate(myAuthenticator) { echoComplete } ~>
-        check { rejection === AuthenticationRequiredRejection("my-scheme", "MyRealm", Map.empty) }
+        check { rejection === AuthenticationRejection }
     }
     "pass on the authenticator extraction if the filter conditions is met" in {
       Get() ~> Host("spray.io") ~> authenticate(myAuthenticator) { echoComplete } ~>

--- a/spray-routing/src/main/scala/spray/routing/authentication/HttpAuthenticator.scala
+++ b/spray-routing/src/main/scala/spray/routing/authentication/HttpAuthenticator.scala
@@ -22,6 +22,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import spray.http._
 import spray.util._
 import HttpHeaders._
+import AuthenticationFailedRejection._
 
 /**
  * An HttpAuthenticator is a ContextAuthenticator that uses credentials passed to the server via the
@@ -34,19 +35,17 @@ trait HttpAuthenticator[U] extends ContextAuthenticator[U] {
     val credentials = authHeader.map { case Authorization(creds) ⇒ creds }
     authenticate(credentials, ctx) map {
       case Some(userContext) ⇒ Right(userContext)
-      case None ⇒ Left {
-        if (authHeader.isEmpty) AuthenticationRequiredRejection(scheme, realm, params(ctx))
-        else AuthenticationFailedRejection(realm)
-      }
+      case None ⇒
+        val cause = if (authHeader.isEmpty) CredentialsMissing else CredentialsRejected
+        Left(AuthenticationFailedRejection(cause, this))
     }
   }
 
   implicit def executionContext: ExecutionContext
-  def scheme: String
-  def realm: String
-  def params(ctx: RequestContext): Map[String, String]
 
   def authenticate(credentials: Option[HttpCredentials], ctx: RequestContext): Future[Option[U]]
+
+  def getChallengeHeaders(httpRequest: HttpRequest): List[HttpHeader]
 }
 
 /**
@@ -54,9 +53,6 @@ trait HttpAuthenticator[U] extends ContextAuthenticator[U] {
  */
 class BasicHttpAuthenticator[U](val realm: String, val userPassAuthenticator: UserPassAuthenticator[U])(implicit val executionContext: ExecutionContext)
     extends HttpAuthenticator[U] {
-
-  def scheme = "Basic"
-  def params(ctx: RequestContext) = Map.empty
 
   def authenticate(credentials: Option[HttpCredentials], ctx: RequestContext) = {
     userPassAuthenticator {
@@ -66,6 +62,10 @@ class BasicHttpAuthenticator[U](val realm: String, val userPassAuthenticator: Us
       }
     }
   }
+
+  def getChallengeHeaders(httpRequest: HttpRequest) =
+    `WWW-Authenticate`(HttpChallenge(scheme = "Basic", realm = realm, params = Map.empty)) :: Nil
+
 }
 
 object BasicAuth {


### PR DESCRIPTION
This pull request fixes #188.

When authentication fails, browsers didn't offer a possibilty to re-enter new credentials because of the missing WWW-Authenticate header. This patch changes the AuthenticationFailedRejection to include "scheme" and "params" fields, just like AuthenticationFailedRejection.
