### PR TITLE
= can: fix request parser not failing early on illegal requests w/o protocol, closes #363

### DIFF
--- a/spray-can/src/main/scala/spray/can/parsing/CharUtils.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/CharUtils.scala
@@ -33,6 +33,7 @@ private[parsing] object CharUtils {
   private final val TOKEN_SPECIALS = 0x10
   private final val TOKEN = ALPHA | DIGIT | TOKEN_SPECIALS
   private final val WSP = 0x20
+  private final val NEWLINE = 0x40
 
   private[this] val props = new Array[Byte](128)
 
@@ -48,10 +49,12 @@ private[parsing] object CharUtils {
   mark(HEX_LETTER, 'A' to 'F')
   mark(TOKEN_SPECIALS, '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~')
   mark(WSP, ' ', '\t')
+  mark(NEWLINE, '\r', '\t')
 
   def isTokenChar(c: Char) = is(c, TOKEN)
   def isDigit(c: Char) = is(c, DIGIT)
   def isWhitespace(c: Char) = is(c, WSP)
+  def isWhitespaceOrNewline(c: Char) = is(c, WSP | NEWLINE)
   def isHexDigit(c: Char) = is(c, HEX_DIGIT)
 
   def hexValue(c: Char): Int = (c & 0x1f) + ((c >> 6) * 0x19) - 0x10

--- a/spray-can/src/main/scala/spray/can/parsing/HttpRequestPartParser.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/HttpRequestPartParser.scala
@@ -75,7 +75,7 @@ class HttpRequestPartParser(_settings: ParserSettings)(_headerParser: HttpHeader
 
     @tailrec def findUriEnd(ix: Int = cursor): Int =
       if (ix == input.length) throw NotEnoughDataException
-      else if (input(ix) == ' ') ix
+      else if (CharUtils.isWhitespaceOrNewline(input(ix).toChar)) ix
       else if (ix < uriEndLimit) findUriEnd(ix + 1)
       else throw new ParsingException(RequestUriTooLong,
         s"URI length exceeds the configured limit of ${settings.maxUriLength} characters")


### PR DESCRIPTION
see #363 
