### PR TITLE
= testkit: dilate default RouteTestTimeout by akka.test.timefactor

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -250,7 +250,7 @@ object Build extends Build with DocSupport {
     .settings(jettyExampleSettings: _*)
     .settings(libraryDependencies ++=
       compile(akkaActor) ++
-      test(specs2) ++
+      test(specs2, akkaTestKit) ++
       runtime(akkaSlf4j, logback) ++
       container(jettyWebApp, servlet30)
     )
@@ -260,7 +260,7 @@ object Build extends Build with DocSupport {
     .settings(standaloneServerExampleSettings: _*)
     .settings(libraryDependencies ++=
       compile(akkaActor) ++
-      test(specs2) ++
+      test(specs2, akkaTestKit) ++
       runtime(akkaSlf4j, logback)
     )
 

--- a/spray-testkit/src/main/scala/spray/testkit/RouteResultComponent.scala
+++ b/spray-testkit/src/main/scala/spray/testkit/RouteResultComponent.scala
@@ -19,8 +19,9 @@ package spray.testkit
 import java.util.concurrent.CountDownLatch
 import concurrent.duration._
 import scala.collection.mutable.ListBuffer
-import akka.actor.{ Status, ActorRefFactory, ActorRef }
+import akka.actor.{ ActorSystem, Status, ActorRefFactory, ActorRef }
 import akka.spray.UnregisteredActorRef
+import akka.testkit._
 import spray.routing.{ RejectionHandler, Rejected, Rejection }
 import spray.http._
 
@@ -115,6 +116,6 @@ trait RouteResultComponent {
   case class RouteTestTimeout(duration: FiniteDuration)
 
   object RouteTestTimeout {
-    implicit val default = RouteTestTimeout(1 second span)
+    implicit def default(implicit system: ActorSystem) = RouteTestTimeout(1.second dilated)
   }
 }


### PR DESCRIPTION
If master travis tests are still failing after the recent #351 merge, this should fix it.
