### PR TITLE
Fix for Issue 373

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/unmarshalling/Unmarshaller.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/unmarshalling/Unmarshaller.scala
@@ -39,4 +39,12 @@ object Unmarshaller {
     new Unmarshaller[T] {
       def apply(entity: HttpEntity) = if (entity.isEmpty) Left(ContentExpected) else um(entity)
     }
+
+  def unmarshaller[T](implicit um: Unmarshaller[T]) = um
+
+  def unmarshal[T: Unmarshaller](entity: HttpEntity): Deserialized[T] = unmarshaller.apply(entity)
+  def unmarshalUnsafe[T: Unmarshaller](entity: HttpEntity): T = unmarshaller.apply(entity) match {
+    case Right(value) ⇒ value
+    case Left(error)  ⇒ sys.error(error.toString)
+  }
 }

--- a/spray-httpx/src/main/scala/spray/httpx/unmarshalling/package.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/unmarshalling/package.scala
@@ -26,12 +26,6 @@ package object unmarshalling {
   type Unmarshaller[T] = Deserializer[HttpEntity, T]
   type FromEntityOptionUnmarshaller[T] = Deserializer[Option[HttpEntity], T]
 
-  def unmarshal[T](implicit um: Unmarshaller[T]) = um
-  def unmarshalUnsafe[T: Unmarshaller](entity: HttpEntity): T = unmarshal.apply(entity) match {
-    case Right(value) ⇒ value
-    case Left(error)  ⇒ sys.error(error.toString)
-  }
-
   implicit def formFieldExtractor(form: HttpForm) = FormFieldExtractor(form)
   implicit def pimpHttpEntity(entity: HttpEntity) = new PimpedHttpEntity(entity)
   implicit def pimpHttpBodyPart(bodyPart: BodyPart) = new PimpedHttpEntity(bodyPart.entity)

--- a/spray-httpx/src/test/scala/spray/httpx/unmarshalling/BasicUnmarshallersSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/unmarshalling/BasicUnmarshallersSpec.scala
@@ -67,4 +67,33 @@ class BasicUnmarshallersSpec extends Specification {
       EmptyEntity.as[String] === Left(ContentExpected)
     }
   }
+
+  "Unmarshaller.unmarshaller" should {
+    "produce the correct unmarshaller" in {
+      val unmarshaller = Unmarshaller.unmarshaller[String]
+
+      unmarshaller(HttpEntity("Hällö")) === Right("Hällö")
+    }
+  }
+
+  "Unmarshaller.unmarshal" should {
+    "succeed when unmarshalling valid entities" in {
+      Unmarshaller.unmarshal[String](HttpEntity("Hällö")) === Right("Hällö")
+    }
+
+    "fail when unmarshalling invalid entities" in {
+      val Left(UnsupportedContentType(msg)) = Unmarshaller.unmarshal[FormData](HttpEntity("Hällö"))
+      msg === "Expected 'application/x-www-form-urlencoded'"
+    }
+  }
+
+  "Unmarshaller.unmarshalUnsafe" should {
+    "correctly unmarshal valid content" in {
+      Unmarshaller.unmarshalUnsafe[String](HttpEntity("Hällö")) === "Hällö"
+    }
+
+    "throw an exception for invalid entities" in {
+      Unmarshaller.unmarshalUnsafe[NodeSeq](HttpEntity("Hällö")) must throwA[RuntimeException]
+    }
+  }
 }


### PR DESCRIPTION
Fixes #377

I think this takes care of the minimum requirements to fix this issue. I added some very basic unit tests because I noticed they were missing.

One more suggestion though: `Unmarshaller.unmarshal[T]` doesn't actually unmarshal anything. It is basically an alias for `implicitly[Unmarshaller[T]]` and the implicit argument list makes it impossible to call it like this:

```
val unmarshalled = unmarshal[String](HttpEntity("a string"))
```

I would suggest renaming it to `unmarshaller[T]` to make it more clear what it actually does. Then we can add `def unmarshal[T: Unmarshaller](entity: HttpEntity): Deserialized[T]` to have parity with `unmarshalUnsafe` again. What do you think?
