### PR TITLE
Fix for issue 317

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
@@ -16,6 +16,7 @@
 
 package spray.httpx
 
+import scala.reflect.ClassTag
 import akka.event.LoggingAdapter
 import spray.httpx.encoding.Encoder
 import spray.httpx.marshalling._
@@ -70,6 +71,12 @@ trait RequestBuilding extends TransformerPipelineSupport {
 
   def removeHeader(headerName: String): RequestTransformer = {
     val selected = (_: HttpHeader).name equalsIgnoreCase headerName
+    _ mapHeaders (_ filterNot selected)
+  }
+
+  def removeHeader[T <: HttpHeader: ClassTag]: RequestTransformer = {
+    val clazz = implicitly[ClassTag[T]].runtimeClass
+    val selected = (header: HttpHeader) ⇒ clazz.isInstance(header)
     _ mapHeaders (_ filterNot selected)
   }
 

--- a/spray-httpx/src/test/scala/spray/httpx/RequestBuildingSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/RequestBuildingSpec.scala
@@ -51,6 +51,12 @@ class RequestBuildingSpec extends Specification with RequestBuilding {
       Get() ~> addHeader("X-Yeah", "Naah") ~> removeHeader("x-yEaH") === HttpRequest(headers = Nil)
     }
 
+    "provide a working `removeHeader` by header type transformer" >> {
+      Get() ~> addHeader("X-Yeah", "Naah") ~> removeHeader[RawHeader] === HttpRequest(headers = Nil)
+      Get() ~> addHeader("X-Yeah", "Naah") ~> addHeader(Authorization(BasicHttpCredentials("bla"))) ~> removeHeader[Authorization] ===
+        HttpRequest(headers = List(RawHeader("X-Yeah", "Naah")))
+    }
+
     "provide a working, case-insensitive `removeHeaders` transformer" >> {
       Get() ~> addHeader("X-Yeah", "Naah") ~>
         addHeader("X-Awesome", "Dude!") ~>


### PR DESCRIPTION
Fixes #317

Added `mapHeaders`, `removeHeader(String)`, and `removeHeaders(String, String*)` to `RequestBuilding`, with the remove functions implemented on top of `_.mapHeaders...` and using explicit toLowerCase for comparing header names.

I also added the matching unit tests.
