### PR TITLE
Change `detachTo` to execute the route in a future rather than an actor

### DIFF
--- a/docs/documentation/spray-routing/code/docs/HttpServiceExamplesSpec.scala
+++ b/docs/documentation/spray-routing/code/docs/HttpServiceExamplesSpec.scala
@@ -74,7 +74,7 @@ class HttpServiceExamplesSpec extends Specification with Specs2RouteTest {
               // unmarshal with in-scope unmarshaller
               entity(as[Order]) { order =>
                 // transfer to newly spawned actor
-                detachTo(singleRequestServiceActor) {
+                detach() {
                   complete {
                     // ... write order to DB
                     "Order received"

--- a/docs/documentation/spray-routing/execution-directives/detach.rst
+++ b/docs/documentation/spray-routing/execution-directives/detach.rst
@@ -1,0 +1,6 @@
+.. _-detach-:
+
+detach
+========
+
+(todo)

--- a/docs/documentation/spray-routing/execution-directives/detachTo.rst
+++ b/docs/documentation/spray-routing/execution-directives/detachTo.rst
@@ -1,6 +1,0 @@
-.. _-detachTo-:
-
-detachTo
-========
-
-(todo)

--- a/docs/documentation/spray-routing/execution-directives/index.rst
+++ b/docs/documentation/spray-routing/execution-directives/index.rst
@@ -6,7 +6,7 @@ ExecutionDirectives
 .. toctree::
    :maxdepth: 1
 
-   detachTo
+   detach
    dynamic
    dynamicIf
    handleExceptions

--- a/docs/documentation/spray-routing/key-concepts/exception-handling.rst
+++ b/docs/documentation/spray-routing/key-concepts/exception-handling.rst
@@ -4,7 +4,8 @@ Exception Handling
 ==================
 
 Exceptions thrown during route execution bubble up throw the route structure up to the next enclosing
-``handleExceptions`` directive, the main ``runRoute`` wrapper or the ``receive`` function of a ``detachTo`` actor.
+``handleExceptions`` directive, the main ``runRoute`` wrapper or the ``onFailure`` callback of a
+future created by ``detach``.
 
 Similarly to the way that :ref:`Rejections` are handled the ``handleExceptions`` directive delegates the actual job of
 converting a list of rejections to its argument, an ExceptionHandler__, which is defined like this::

--- a/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
+++ b/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
@@ -33,7 +33,7 @@ Directive                              Description
 :ref:`-delete-`                        Rejects all non-DELETE requests
 :ref:`-deleteCookie-`                  Adds a ``Set-Cookie`` header expiring the given cookie to all ``HttpResponse``
                                        replies of its inner Route
-:ref:`-detachTo-`                      Executes its inner Route in the context of the actor returned by a given function
+:ref:`-detach-`                        Executes its inner Route in a ``Future``
 :ref:`-dynamic-`                       Rebuilds its inner Route for every request anew
 :ref:`-dynamicIf-`                     Conditionally rebuilds its inner Route for every request anew
 :ref:`-encodeResponse-`                Compresses responses coming back from its inner Route using a given Decoder

--- a/examples/spray-routing/on-jetty/src/main/scala/spray/examples/DemoService.scala
+++ b/examples/spray-routing/on-jetty/src/main/scala/spray/examples/DemoService.scala
@@ -44,8 +44,8 @@ trait DemoService extends HttpService {
         complete("PONG!")
       } ~
       path("stream1") {
-        // we detach in order to move the blocking code inside the simpleStringStream off the service actor
-        detachTo(singleRequestServiceActor) {
+        // we detach in order to move the blocking code inside the simpleStringStream into a future
+        detach() {
           complete(simpleStringStream)
         }
       } ~

--- a/examples/spray-routing/on-spray-can/src/main/scala/spray/examples/DemoService.scala
+++ b/examples/spray-routing/on-spray-can/src/main/scala/spray/examples/DemoService.scala
@@ -47,8 +47,8 @@ trait DemoService extends HttpService {
         complete("PONG!")
       } ~
       path("stream1") {
-        // we detach in order to move the blocking code inside the simpleStringStream off the service actor
-        detachTo(singleRequestServiceActor) {
+        // we detach in order to move the blocking code inside the simpleStringStream into a future
+        detach() {
           complete(simpleStringStream)
         }
       } ~


### PR DESCRIPTION
This fixes issue #240.

I've removed the previous detachTo directive so this breaks the API. The file directives that use `detachTo` now take an implicit `ExecutionContext`. I wasn't able to remove the `ActorRefFactory` since it is needed for stream marshalling and also to get the class loader of the actor system, when loading from resources. 

I considered renaming the directive to `detach` since the `ExecutionContext` is implicit. Unfortunately, in the most common use case it is necessary to explicitly pass in the `ExecutionContext`.

``` scala
implicit val executionContext = ...

get {
  detachTo { // doesn't compile
    ...
  }
} 

get {
  detachTo(executionContext) {
    ...
  }
} 

(get & detachTo) {
  ...
}
```

Also, the commit messages do not follow the guidelines, but I'll squash the commits after someone reviews this. 
