### PR TITLE
Validate JSONP callback parameter

### DIFF
--- a/spray-routing-tests/src/test/scala/spray/routing/MiscDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/MiscDirectivesSpec.scala
@@ -18,8 +18,9 @@ package spray.routing
 
 import spray.http._
 import HttpHeaders._
-import MediaTypes._
 import HttpMethods._
+import MediaTypes._
+import Uri._
 
 class MiscDirectivesSpec extends RoutingSpec {
 
@@ -69,6 +70,13 @@ class MiscDirectivesSpec extends RoutingSpec {
           complete(HttpResponse(entity = HttpEntity(`text/plain`, "[1,2,3]")))
         }
       } ~> check { body === HttpEntity(`text/plain`, "[1,2,3]") }
+    }
+    "reject invalid / insecure callback identifiers" in {
+      Get(Uri.from(path = "/", query = Query("jsonp" -> "(function xss(x){evil()})"))) ~> {
+        jsonpWithParameter("jsonp") {
+          complete(HttpResponse(entity = HttpEntity(`text/plain`, "[1,2,3]")))
+        }
+      } ~> check { rejections === Seq(MalformedQueryParamRejection("jsonp", "Invalid JSONP callback identifier")) }
     }
   }
 


### PR DESCRIPTION
Fixes #308.

The callback parameter is validated to only include alphanumeric, underscore (_), dollar ($) and dot (.) characters. Otherwise the request is rejected with MalformedQueryParamRejection.

The regex can definitely be improved since it still allows invalid javascript identifiers and rejects valid ones (e.g. foo[0]). Still, it seems to prevent the XSS exploits while allowing the most common usage. Let me know you what you think.

The commit messages do not follow the guidelines, but I'll squash the commits after someone reviews this.
