### PR TITLE
+ http: fix recent MediaType refactoring causing `*/*;q=?` mismatch, add tests

### DIFF
--- a/spray-http/src/main/scala/spray/http/MediaType.scala
+++ b/spray-http/src/main/scala/spray/http/MediaType.scala
@@ -68,7 +68,7 @@ object MediaRange {
 
   private case class CustomMediaRange(value: String)(val mainType: String, val parameters: Map[String, String],
                                                      val qValue: Float) extends MediaRange with MainTypeBased {
-    def matches(mediaType: MediaType) = mediaType.mainType == mainType
+    def matches(mediaType: MediaType) = mainType == "*" || mediaType.mainType == mainType
     type Self = MediaRange
     protected def copyWith(qValue: Double, parameters: Map[String, String]) = custom(mainType, parameters, qValue)
   }
@@ -133,6 +133,7 @@ sealed abstract case class MediaType private[http] (value: String)(val mainType:
                                                                    val qValue: Float) extends MediaRange {
   type Self <: MediaType
   override def matches(mediaType: MediaType) = mediaType.mainType == mainType && mediaType.subType == subType
+  def withCharset(charset: HttpCharset): ContentType = ContentType(this, charset)
 }
 
 class MultipartMediaType private[http] (_value: String, _subType: String, _parameters: Map[String, String], _qValue: Float)

--- a/spray-http/src/test/scala/spray/http/ContentNegotiationSpec.scala
+++ b/spray-http/src/test/scala/spray/http/ContentNegotiationSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2011-2013 spray.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spray.http
+
+import org.specs2.mutable.Specification
+import org.specs2.execute.{ Failure, FailureException }
+import spray.http.parser.HttpParser
+import HttpHeaders._
+import MediaTypes._
+import HttpCharsets._
+
+class ContentNegotiationSpec extends Specification {
+
+  "Content Negotiation" should {
+    "work properly for requests with header(s)" in {
+
+      "(without headers)" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/plain` withCharset `UTF-16`) must select(`text/plain`, `UTF-16`)
+      }
+
+      "Accept: */*" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/plain` withCharset `UTF-16`) must select(`text/plain`, `UTF-16`)
+      }
+
+      "Accept: */*;q=.8" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/plain` withCharset `UTF-16`) must select(`text/plain`, `UTF-16`)
+      }
+
+      "Accept: text/*" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/xml` withCharset `UTF-16`) must select(`text/xml`, `UTF-16`)
+        accept(`audio/ogg`) must reject
+      }
+
+      "Accept: text/*;q=.8" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/xml` withCharset `UTF-16`) must select(`text/xml`, `UTF-16`)
+        accept(`audio/ogg`) must reject
+      }
+
+      "Accept: text/*;q=0" ! test { accept ⇒
+        accept(`text/plain`) must reject
+        accept(`text/xml` withCharset `UTF-16`) must reject
+        accept(`audio/ogg`) must reject
+      }
+
+      "Accept-Charset: UTF-16" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-16`)
+        accept(`text/plain` withCharset `UTF-8`) must reject
+      }
+
+      "Accept-Charset: *" ! test { accept ⇒
+        accept(`text/plain`) must select(`text/plain`, `UTF-8`)
+        accept(`text/plain` withCharset `UTF-16`) must select(`text/plain`, `UTF-16`)
+      }
+
+      "Accept: text/xml, text/html;q=.5" ! test { accept ⇒
+        accept(`text/plain`) must reject
+        accept(`text/xml`) must select(`text/xml`, `UTF-8`)
+        accept(`text/html`) must select(`text/html`, `UTF-8`)
+        accept(`text/html`, `text/xml`) must select(`text/xml`, `UTF-8`)
+        accept(`text/xml`, `text/html`) must select(`text/xml`, `UTF-8`)
+        accept(`text/plain`, `text/xml`) must select(`text/xml`, `UTF-8`)
+        accept(`text/plain`, `text/html`) must select(`text/html`, `UTF-8`)
+      }
+
+      """Accept: text/html, text/plain;q=0.8, application/*;q=.5, *;q= .2
+         Accept-Charset: UTF-16""" ! test { accept ⇒
+        accept(`text/plain`, `text/html`, `audio/ogg`) must select(`text/html`, `UTF-16`)
+        accept(`text/plain`, `text/html` withCharset `UTF-8`, `audio/ogg`) must select(`text/plain`, `UTF-16`)
+        accept(`audio/ogg`, `application/javascript`, `text/plain` withCharset `UTF-8`) must select(`application/javascript`, `UTF-16`)
+        accept(`image/gif`, `application/javascript`) must select(`application/javascript`, `UTF-16`)
+        accept(`image/gif`, `audio/ogg`) must select(`image/gif`, `UTF-16`)
+      }
+    }
+  }
+
+  def test[U](body: ((ContentType*) ⇒ Option[ContentType]) ⇒ U): String ⇒ U = { example ⇒
+    val headers =
+      if (example != "(without headers)") {
+        example.split('\n').toList map { rawHeader ⇒
+          val Array(name, value) = rawHeader.split(':')
+          HttpParser.parseHeader(RawHeader(name.trim, value.trim)) match {
+            case Right(header) ⇒ header
+            case Left(err)     ⇒ throw new FailureException(Failure(err.formatPretty))
+          }
+        }
+      } else Nil
+    val request = HttpRequest(headers = headers)
+    body(request.acceptableContentType)
+  }
+
+  def reject = beEqualTo(None)
+  def select(mediaType: MediaType, charset: HttpCharset) = beEqualTo(Some(ContentType(mediaType, charset)))
+}


### PR DESCRIPTION
This change also add a `def withCharset(charset: HttpCharset): ContentType`
convenience method to `MediaType`.
