### PR TITLE
+ io: don't abort connection immediately when `finishConnect` returns false but retry selection, fix #390

### DIFF
--- a/spray-io/src/main/resources/reference.conf
+++ b/spray-io/src/main/resources/reference.conf
@@ -85,6 +85,11 @@ akka {
       # IO is faster than file IO. Decreasing the value may improve fairness while increasing
       # may improve throughput.
       file-io-transferTo-limit = 512 KiB
+
+      # The number of times to retry the `finishConnect` call after being notified about
+      # OP_CONNECT. Retries are needed if the OP_CONNECT notification doesn't imply that
+      # `finishConnect` will succeed. However, on Android this assumption isn't true.
+      finish-connect-retries = 5
     }
 
     udp {

--- a/spray-io/src/main/scala/akka/io/Tcp.scala
+++ b/spray-io/src/main/scala/akka/io/Tcp.scala
@@ -453,9 +453,11 @@ class TcpExt(system: ExtendedActorSystem) extends IO.Extension {
     }
 
     val MaxChannelsPerSelector: Int = if (MaxChannels == -1) -1 else math.max(MaxChannels / NrOfSelectors, 1)
+    val FinishConnectRetries: Int = getInt("finish-connect-retries")
 
     require(NrOfSelectors > 0, "nr-of-selectors must be > 0")
     require(BatchAcceptLimit > 0, "batch-accept-limit must be > 0")
+    require(FinishConnectRetries > 0, "finish-connect-retries must be > 0")
 
     private[this] def getIntBytes(path: String): Int = {
       val size = getBytes(path)

--- a/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -9,6 +9,7 @@ import java.nio.channels.{ SelectionKey, SocketChannel }
 import java.net.ConnectException
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import akka.actor.{ ReceiveTimeout, ActorRef }
 import akka.io.Inet.SocketOption
 import akka.io.TcpConnection.CloseInformation
@@ -42,20 +43,32 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
       if (channel.connect(remoteAddress))
         completeConnect(registration, commander, options)
       else
-        context.become(connecting(registration, commander, options))
+        context.become(connecting(registration, commander, options, tcp.Settings.FinishConnectRetries))
   }
 
   def connecting(registration: ChannelRegistration, commander: ActorRef,
-                 options: immutable.Traversable[SocketOption]): Receive = {
+                 options: immutable.Traversable[SocketOption], remainingFinishConnectRetries: Int): Receive = {
     def stop(): Unit = stopWith(CloseInformation(Set(commander), connect.failureMessage))
 
     {
       case ChannelConnectable ⇒
-        if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
         try {
-          channel.finishConnect() || (throw new ConnectException(s"Connection to [$remoteAddress] failed"))
-          log.debug("Connection established to [{}]", remoteAddress)
-          completeConnect(registration, commander, options)
+          if (channel.finishConnect()) {
+            if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
+            log.debug("Connection established to [{}]", remoteAddress)
+            completeConnect(registration, commander, options)
+          } else {
+            if (remainingFinishConnectRetries > 0) {
+              context.system.scheduler.scheduleOnce(1.millisecond) {
+                channelRegistry.register(channel, SelectionKey.OP_CONNECT)
+              }(context.dispatcher)
+              context.become(connecting(registration, commander, options, remainingFinishConnectRetries - 1))
+            } else {
+              log.debug("Could not establish connection because finishConnect " +
+                "never returned true (consider increasing akka.io.tcp.finish-connect-retries)")
+              stop()
+            }
+          }
         } catch {
           case e: IOException ⇒
             log.debug("Could not establish connection due to {}", e)


### PR DESCRIPTION
Before closing we should 
- wait for confirmation that the default setting of 5 retries really fixes the problem
- add a ticket for akka for the same issue
