### PR TITLE
! can: when creating HostConnectorSettings expect client settings at `spray.can.client`, fixes #408

### DIFF
--- a/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
+++ b/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
@@ -32,11 +32,11 @@ case class HostConnectorSettings(
   requirePositiveOrUndefined(idleTimeout)
 }
 
-object HostConnectorSettings extends SettingsCompanion[HostConnectorSettings]("spray.can.host-connector") {
+object HostConnectorSettings extends SettingsCompanion[HostConnectorSettings]("spray.can") {
   def fromSubConfig(c: Config) = apply(
-    c getInt "max-connections",
-    c getInt "max-retries",
-    c getBoolean "pipelining",
-    c getDuration "idle-timeout",
+    c getInt "host-connector.max-connections",
+    c getInt "host-connector.max-retries",
+    c getBoolean "host-connector.pipelining",
+    c getDuration "host-connector.idle-timeout",
     ClientConnectionSettings fromSubConfig c.getConfig("client"))
 }

--- a/spray-client/src/test/scala/spray/client/HttpHostConnectorSpec.scala
+++ b/spray-client/src/test/scala/spray/client/HttpHostConnectorSpec.scala
@@ -40,7 +40,8 @@ class HttpHostConnectorSpec extends Specification with NoTimeConversions {
     akka.loglevel = WARNING
     akka.io.tcp.trace-logging = off
     spray.can.host-connector.max-retries = 2
-    spray.can.host-connector.client.request-timeout = 400ms""")
+    spray.can.host-connector.client.request-timeout = 400ms
+    spray.can.client.user-agent-header = "RequestMachine"""")
   implicit val system = ActorSystem(Utils.actorSystemNameFrom(getClass), testConf)
   import system.dispatcher
   val (interface, port) = Utils.temporaryServerHostnameAndPort()
@@ -62,7 +63,8 @@ class HttpHostConnectorSpec extends Specification with NoTimeConversions {
           case x @ HttpRequest(method, uri, _, entity, _) ⇒
             log.debug("Responding to " + x)
             dropNext = random.nextBoolean()
-            sender ! HttpResponse(entity = method + "|" + uri.path + (if (entity.isEmpty) "" else "|" + entity.asString))
+            val mirroredHeaders = x.header[HttpHeaders.`User-Agent`].toList
+            sender ! HttpResponse(entity = method + "|" + uri.path + (if (entity.isEmpty) "" else "|" + entity.asString), headers = mirroredHeaders)
           case Timedout(request)         ⇒ sender ! HttpResponse(entity = "TIMEOUT")
           case ev: Http.ConnectionClosed ⇒ log.debug("Received " + ev)
         }
@@ -105,6 +107,11 @@ class HttpHostConnectorSpec extends Specification with NoTimeConversions {
         Future.traverse(requests)(pipeline).map(responses2 ⇒ responses1.zip(responses2))
       }
       future.await.map { case (a, b) ⇒ a.entity === b.entity }.reduceLeft(_ and _)
+    }
+    "should honor the global spray.can.client settings" in {
+      val Http.HostConnectorInfo(connector, _) = IO(Http).ask(Http.HostConnectorSetup(interface, port)).await
+      val pipeline = sendReceive(connector)
+      pipeline(HttpRequest()).await.header[HttpHeaders.`User-Agent`].get.value === "RequestMachine"
     }
   }
 


### PR DESCRIPTION
instead of at `spray.can.host-connector.client`.
