### PR TITLE
+ routing: add scheme directives

### DIFF
--- a/docs/documentation/spray-routing/code/docs/directives/SchemeDirectivesExamplesSpec.scala
+++ b/docs/documentation/spray-routing/code/docs/directives/SchemeDirectivesExamplesSpec.scala
@@ -1,0 +1,39 @@
+package docs.directives
+
+import spray.http.Uri
+import spray.http.StatusCodes._
+import spray.http.HttpHeaders._
+
+class SchemeDirectivesExamplesSpec extends DirectivesSpec {
+  "example-1" in {
+    val route =
+      schemeName { scheme =>
+        complete(s"The scheme is '${scheme}'")
+      }
+
+    Get("https://www.example.com/") ~> route ~> check {
+      entityAs[String] === "The scheme is 'https'"
+    }
+  }
+
+  "example-2" in {
+    val route =
+      scheme("http") {
+        extract(_.request.uri) { uri ⇒
+          redirect(uri.copy(scheme = "https"), MovedPermanently)
+        }
+      } ~
+      scheme("https") {
+        complete(s"Safe and secure!")
+      }
+
+    Get("http://www.example.com/hello") ~> route ~> check {
+      status === MovedPermanently
+      header[Location] === Some(Location(Uri("https://www.example.com/hello")))
+    }
+
+    Get("https://www.example.com/hello") ~> route ~> check {
+      entityAs[String] === "Safe and secure!"
+    }
+  }
+}

--- a/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
+++ b/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
@@ -151,6 +151,8 @@ Directive                              Description
 :ref:`-rewriteUnmatchedPath-`          Transforms the ``unmatchedPath`` of the ``RequestContext`` using a given function
 :ref:`-routeRouteResponse-`            Chains a partial function into the response chain, which, for certain responses
                                        from its inner route, produces another route that is to be applied instead
+:ref:`-scheme-`                        Rejects a request if its Uri scheme does not match a given one
+:ref:`-schemeName-`                    Extracts the request Uri scheme
 :ref:`-setCookie-`                     Adds a ``Set-Cookie`` header to all ``HttpResponse`` replies of its inner Route
 :ref:`-unmatchedPath-`                 Extracts the unmatched path from the RequestContext
 :ref:`-validate-`                      Passes or rejects the request depending on evaluation of a given conditional

--- a/docs/documentation/spray-routing/predefined-directives-by-trait.rst
+++ b/docs/documentation/spray-routing/predefined-directives-by-trait.rst
@@ -32,4 +32,5 @@ You can browse the predefined directives by trait:
    path-directives/index
    respond-with-directives/index
    route-directives/index
+   scheme-directives/index
    security-directives/index

--- a/docs/documentation/spray-routing/scheme-directives/index.rst
+++ b/docs/documentation/spray-routing/scheme-directives/index.rst
@@ -1,0 +1,13 @@
+.. _SchemeDirectives:
+
+SchemeDirectives
+================
+
+Scheme directives can be used to extract the Uri scheme (i.e. "http", "https", etc.)
+from requests or to reject any request that does not match a specified scheme name.
+
+.. toctree::
+   :maxdepth: 1
+
+   scheme
+   schemeName

--- a/docs/documentation/spray-routing/scheme-directives/scheme.rst
+++ b/docs/documentation/spray-routing/scheme-directives/scheme.rst
@@ -1,0 +1,31 @@
+.. _-scheme-:
+
+scheme
+======
+
+Rejects a request if its Uri scheme does not match a given one.
+
+Signature
+---------
+
+.. includecode:: /../spray-routing/src/main/scala/spray/routing/directives/SchemeDirectives.scala
+   :snippet: scheme
+
+Description
+-----------
+
+The ``scheme`` directive can be used to match requests by their Uri scheme, only passing
+through requests that match the specified scheme and rejecting all others.
+
+A typical use case for the ``scheme`` directive would be to reject requests coming in over
+http instead of https, or to redirect such requests to the matching https URI with a
+``MovedPermanently``.
+
+For simply extracting the scheme name, see the :ref:`-schemeName-` directive.
+
+Example
+-------
+
+.. includecode:: ../code/docs/directives/SchemeDirectivesExamplesSpec.scala
+   :snippet: example-2
+

--- a/docs/documentation/spray-routing/scheme-directives/schemeName.rst
+++ b/docs/documentation/spray-routing/scheme-directives/schemeName.rst
@@ -1,0 +1,26 @@
+.. _-schemeName-:
+
+schemeName
+==========
+
+Extracts the value of the request Uri scheme.
+
+Signature
+---------
+
+.. includecode:: /../spray-routing/src/main/scala/spray/routing/directives/SchemeDirectives.scala
+   :snippet: schemeName
+
+Description
+-----------
+
+The ``schemeName`` directive can be used to determine the Uri scheme (i.e. "http", "https", etc.)
+for an incoming request.
+
+For rejecting a request if it doesn't match a specified scheme name, see the :ref:`-scheme-` directive.
+
+Example
+-------
+
+.. includecode:: ../code/docs/directives/SchemeDirectivesExamplesSpec.scala
+   :snippet: example-1

--- a/spray-routing-tests/src/test/scala/spray/routing/RejectionHandlerSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/RejectionHandlerSpec.scala
@@ -98,6 +98,14 @@ class RejectionHandlerSpec extends RoutingSpec {
         entityAs[String] === "HTTP method not allowed, supported methods: GET, PUT"
       }
     }
+    "respond with BadRequest for requests resulting in SchemeRejections" in {
+      Get("http://example.com/hello") ~> wrap {
+        scheme("https") { complete("yes") }
+      } ~> check {
+        status === BadRequest
+        entityAs[String] === "Uri scheme not allowed, supported schemes: https"
+      }
+    }
     "respond with BadRequest for requests resulting in a MissingFormFieldRejection" in {
       Get() ~> wrap {
         formFields('amount, 'orderId) { (_, _) ⇒ completeOk }

--- a/spray-routing-tests/src/test/scala/spray/routing/SchemeDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/SchemeDirectivesSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2011-2013 spray.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spray.routing
+
+class SchemeDirectivesSpec extends RoutingSpec {
+  "the schemeName directive" should {
+    "extract the Uri scheme" in {
+      Put("http://localhost/", "Hello") ~> schemeName { echoComplete } ~> check { entityAs[String] === "http" }
+    }
+  }
+
+  """the scheme("http") directive""" should {
+    "let requests with an http Uri scheme pass" in {
+      Put("http://localhost/", "Hello") ~> scheme("http") { completeOk } ~> check { response === Ok }
+    }
+    "reject requests with an https Uri scheme" in {
+      Get("https://localhost/") ~> scheme("http") { completeOk } ~> check { rejection === SchemeRejection("http") }
+    }
+  }
+
+  """the scheme("https") directive""" should {
+    "let requests with an https Uri scheme pass" in {
+      Put("https://localhost/", "Hello") ~> scheme("https") { completeOk } ~> check { response === Ok }
+    }
+    "reject requests with an http Uri scheme" in {
+      Get("http://localhost/") ~> scheme("https") { completeOk } ~> check { rejection === SchemeRejection("https") }
+    }
+  }
+}

--- a/spray-routing/src/main/scala/spray/routing/Directives.scala
+++ b/spray-routing/src/main/scala/spray/routing/Directives.scala
@@ -39,6 +39,7 @@ trait Directives extends RouteConcatenation
   with PathDirectives
   with RespondWithDirectives
   with RouteDirectives
+  with SchemeDirectives
   with SecurityDirectives
 
 object Directives extends Directives

--- a/spray-routing/src/main/scala/spray/routing/Rejection.scala
+++ b/spray-routing/src/main/scala/spray/routing/Rejection.scala
@@ -33,6 +33,12 @@ trait Rejection
 case class MethodRejection(supported: HttpMethod) extends Rejection
 
 /**
+ * Rejection created by scheme filters.
+ * Signals that the request was rejected because the Uri scheme is unsupported.
+ */
+case class SchemeRejection(supported: String) extends Rejection
+
+/**
  * Rejection created by parameter filters.
  * Signals that the request was rejected because a query parameter was not found.
  */

--- a/spray-routing/src/main/scala/spray/routing/RejectionHandler.scala
+++ b/spray-routing/src/main/scala/spray/routing/RejectionHandler.scala
@@ -66,6 +66,10 @@ object RejectionHandler {
       val methods = rejections.collect { case MethodRejection(method) ⇒ method }
       complete(MethodNotAllowed, "HTTP method not allowed, supported methods: " + methods.mkString(", "))
 
+    case rejections @ (SchemeRejection(_) :: _) ⇒
+      val schemes = rejections.collect { case SchemeRejection(scheme) ⇒ scheme }
+      complete(BadRequest, "Uri scheme not allowed, supported schemes: " + schemes.mkString(", "))
+
     case MissingCookieRejection(cookieName) :: _ ⇒
       complete(BadRequest, "Request is missing required cookie '" + cookieName + '\'')
 

--- a/spray-routing/src/main/scala/spray/routing/directives/SchemeDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/SchemeDirectives.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2011-2013 spray.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package spray.routing
+package directives
+
+import shapeless.HNil
+
+trait SchemeDirectives {
+  import BasicDirectives._
+  import MiscDirectives._
+  import RouteDirectives._
+
+  /**
+   * Extracts the Uri scheme from the request.
+   */
+  def schemeName: Directive1[String] = extract(_.request.uri.scheme)
+
+  /**
+   * Rejects all requests whose Uri scheme does not match the given one.
+   */
+  def scheme(schm: String): Directive0 =
+    schemeName.require(_ == schm, SchemeRejection(schm)) &
+      cancelAllRejections(ofType[SchemeRejection])
+}
+
+object SchemeDirectives extends SchemeDirectives


### PR DESCRIPTION
I added a new SchemeDirectives trait that allows you to reject routes based on the Uri scheme.This was just something I thought of when thinking about how to redirect all requests for "http" uris to the relevant "https" uris and I think they can be of general use.

I just implemented the `http` and `https` directives plus the generic `scheme` directive they are built upon. Since Spray == HTTP and it doesn't support web sockets yet, I didn't think more schemes were needed.

I updated the documentation with basic directive descriptions in the relevant indexes but I left the detailed documentation for later, mainly due to a lack of any existing examples to use for inspiration :)
