### PR TITLE
Prevent NPE when dispatching response to closed connection

### DIFF
--- a/spray-can/src/main/scala/spray/can/server/ResponseReceiverRef.scala
+++ b/spray-can/src/main/scala/spray/can/server/ResponseReceiverRef.scala
@@ -77,10 +77,8 @@ private class ResponseReceiverRef(openRequest: OpenRequest)
   }
 
   private def unhandledMessage(message: Any)(implicit sender: ActorRef): Unit = {
-    val context = openRequest.context // we were seeing NPEs somewhere here
-    val system = context.system // so we split into several lines to
-    val evStream = system.eventStream // be able to better locate the problem
-    evStream.publish(UnhandledMessage(message, sender, this))
+    val ac = openRequest.context.actorContext
+    if (ac != null) ac.system.eventStream.publish(UnhandledMessage(message, sender, this))
   }
 
   private def requestInfo = openRequest.request.method.toString + " request to '" + openRequest.request.uri + '\''


### PR DESCRIPTION
Fixes the NPE that is thrown when a request completes after a timeout has occurred and the connection has been closed. See #387

Before using the actorContext, it is checked that it has not become null.
