### PR TITLE
+ httpx: add support for specifying an optional log level with logRequest and logResponse

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/RequestBuilding.scala
@@ -17,7 +17,7 @@
 package spray.httpx
 
 import scala.reflect.ClassTag
-import akka.event.LoggingAdapter
+import akka.event.{ Logging, LoggingAdapter }
 import spray.httpx.encoding.Encoder
 import spray.httpx.marshalling._
 import spray.http.parser.HttpParser
@@ -87,7 +87,7 @@ trait RequestBuilding extends TransformerPipelineSupport {
 
   def addCredentials(credentials: HttpCredentials) = addHeader(HttpHeaders.Authorization(credentials))
 
-  def logRequest(log: LoggingAdapter) = logValue[HttpRequest](log)
+  def logRequest(log: LoggingAdapter, level: Logging.LogLevel = Logging.DebugLevel) = logValue[HttpRequest](log, level)
 
   def logRequest(logFun: HttpRequest ⇒ Unit) = logValue[HttpRequest](logFun)
 

--- a/spray-httpx/src/main/scala/spray/httpx/ResponseTransformation.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/ResponseTransformation.scala
@@ -16,7 +16,7 @@
 
 package spray.httpx
 
-import akka.event.LoggingAdapter
+import akka.event.{ Logging, LoggingAdapter }
 import spray.httpx.unmarshalling._
 import spray.httpx.encoding.Decoder
 import spray.http._
@@ -36,7 +36,7 @@ trait ResponseTransformation extends TransformerPipelineSupport {
         }
       else throw new UnsuccessfulResponseException(response)
 
-  def logResponse(log: LoggingAdapter) = logValue[HttpResponse](log)
+  def logResponse(log: LoggingAdapter, level: Logging.LogLevel = Logging.DebugLevel) = logValue[HttpResponse](log, level)
 
   def logResponse(logFun: HttpResponse ⇒ Unit) = logValue[HttpResponse](logFun)
 }


### PR DESCRIPTION
The default log level is still DEBUG but now you can specify your own level. This was already exposed by logValue but had not bubbled up to logRequest/logResponse.
