### PR TITLE
! util: Swap Duration.Undefined by Duration.Inf, fixes #440

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
@@ -36,6 +36,7 @@ class SprayCanClientSpec extends Specification {
     akka.io.tcp.trace-logging = off
     spray.can.client.request-timeout = 500ms
     spray.can.host-connector.max-retries = 1
+    spray.can.host-connector.idle-timeout = infinite
     spray.can.host-connector.client.request-timeout = 500ms
     spray.can.server.request-chunk-aggregation-limit = 0
     spray.can.client.response-chunk-aggregation-limit = 0""")

--- a/spray-can/src/main/scala/spray/can/client/ClientConnectionSettings.scala
+++ b/spray-can/src/main/scala/spray/can/client/ClientConnectionSettings.scala
@@ -32,14 +32,14 @@ case class ClientConnectionSettings(
     connectingTimeout: Duration,
     parserSettings: ParserSettings) {
 
-  requirePositiveOrUndefined(idleTimeout)
-  requirePositiveOrUndefined(requestTimeout)
-  requirePositiveOrUndefined(reapingCycle)
+  requirePositive(idleTimeout)
+  requirePositive(requestTimeout)
+  requirePositive(reapingCycle)
   require(0 <= responseChunkAggregationLimit && responseChunkAggregationLimit <= Int.MaxValue,
     "response-chunk-aggregation-limit must be >= 0 and <= Int.MaxValue")
   require(0 <= requestSizeHint && requestSizeHint <= Int.MaxValue,
     "request-size-hint must be >= 0 and <= Int.MaxValue")
-  requirePositiveOrUndefined(connectingTimeout)
+  requirePositive(connectingTimeout)
 }
 
 object ClientConnectionSettings extends SettingsCompanion[ClientConnectionSettings]("spray.can.client") {

--- a/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
+++ b/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
@@ -29,7 +29,7 @@ case class HostConnectorSettings(
 
   require(maxConnections > 0, "max-connections must be > 0")
   require(maxRetries >= 0, "max-retries must be >= 0")
-  requirePositiveOrUndefined(idleTimeout)
+  requirePositive(idleTimeout)
 }
 
 object HostConnectorSettings extends SettingsCompanion[HostConnectorSettings]("spray.can") {

--- a/spray-can/src/main/scala/spray/can/server/ServerFrontend.scala
+++ b/spray-can/src/main/scala/spray/can/server/ServerFrontend.scala
@@ -25,7 +25,6 @@ import spray.can.rendering.ResponsePartRenderingContext
 import spray.can.Http
 import spray.http._
 import spray.io._
-import spray.util.requirePositiveOrUndefined
 
 object ServerFrontend {
 

--- a/spray-can/src/main/scala/spray/can/server/ServerSettings.scala
+++ b/spray-can/src/main/scala/spray/can/server/ServerSettings.scala
@@ -48,18 +48,18 @@ case class ServerSettings(
     backpressureSettings: Option[BackpressureSettings],
     parserSettings: ParserSettings) {
 
-  requirePositiveOrUndefined(idleTimeout)
-  requirePositiveOrUndefined(requestTimeout)
-  requirePositiveOrUndefined(timeoutTimeout)
-  requirePositiveOrUndefined(idleTimeout)
+  requirePositive(idleTimeout)
+  requirePositive(requestTimeout)
+  requirePositive(timeoutTimeout)
+  requirePositive(idleTimeout)
   require(0 <= pipeliningLimit && pipeliningLimit <= 128, "pipelining-limit must be >= 0 and <= 128")
   require(0 <= requestChunkAggregationLimit && requestChunkAggregationLimit <= Int.MaxValue,
     "request-chunk-aggregation-limit must be >= 0 and <= Int.MaxValue")
   require(0 <= responseSizeHint && responseSizeHint <= Int.MaxValue,
     "response-size-hint must be >= 0 and <= Int.MaxValue")
-  requirePositiveOrUndefined(bindTimeout)
-  requirePositiveOrUndefined(unbindTimeout)
-  requirePositiveOrUndefined(registrationTimeout)
+  requirePositive(bindTimeout)
+  requirePositive(unbindTimeout)
+  requirePositive(registrationTimeout)
 
   require(!requestTimeout.isFinite || idleTimeout > requestTimeout,
     "idle-timeout must be > request-timeout (if the latter is not 'infinite')")

--- a/spray-io/src/main/scala/spray/io/ConnectionTimeouts.scala
+++ b/spray-io/src/main/scala/spray/io/ConnectionTimeouts.scala
@@ -18,13 +18,13 @@ package spray.io
 
 import scala.concurrent.duration.Duration
 import akka.io.Tcp
-import spray.util.requirePositiveOrUndefined
+import spray.util.requirePositive
 import System.{ currentTimeMillis ⇒ now }
 
 object ConnectionTimeouts {
 
   def apply(idleTimeout: Duration): PipelineStage = {
-    requirePositiveOrUndefined(idleTimeout)
+    requirePositive(idleTimeout)
 
     new PipelineStage {
       def apply(context: PipelineContext, commandPL: CPL, eventPL: EPL): Pipelines = new Pipelines {
@@ -62,6 +62,6 @@ object ConnectionTimeouts {
   ////////////// COMMANDS //////////////
 
   case class SetIdleTimeout(timeout: Duration) extends Command {
-    requirePositiveOrUndefined(timeout)
+    requirePositive(timeout)
   }
 }

--- a/spray-servlet/src/main/scala/spray/servlet/ConnectorSettings.scala
+++ b/spray-servlet/src/main/scala/spray/servlet/ConnectorSettings.scala
@@ -34,8 +34,8 @@ case class ConnectorSettings(
 
   require(!bootClass.isEmpty,
     "No boot class configured. Please specify a boot class FQN in the spray.servlet.boot-class config setting.")
-  requirePositiveOrUndefined(requestTimeout)
-  requirePositiveOrUndefined(timeoutTimeout)
+  requirePositive(requestTimeout)
+  requirePositive(timeoutTimeout)
   require(maxContentLength > 0, "max-content-length must be > 0")
 
   val rootPathCharCount = rootPath.charCount

--- a/spray-servlet/src/test/scala/spray/servlet/ModelConverterSpec.scala
+++ b/spray-servlet/src/test/scala/spray/servlet/ModelConverterSpec.scala
@@ -33,8 +33,8 @@ class ModelConverterSpec extends Specification with NoTimeConversions {
   implicit def noLogging = NoLogging
   val settings = ConnectorSettings(
     bootClass = "xxx",
-    requestTimeout = Duration.Undefined,
-    timeoutTimeout = Duration.Undefined,
+    requestTimeout = Duration.Inf,
+    timeoutTimeout = Duration.Inf,
     timeoutHandler = "",
     rootPath = Uri.Path.Empty,
     remoteAddressHeader = false,

--- a/spray-util/src/main/scala/spray/util/Macros.scala
+++ b/spray-util/src/main/scala/spray/util/Macros.scala
@@ -21,12 +21,12 @@ import scala.concurrent.duration.Duration
 
 private[spray] object Macros {
 
-  def requirePositiveOrUndefined(c: Context)(duration: c.Expr[Duration]) = {
+  def requirePositive(c: Context)(duration: c.Expr[Duration]) = {
     import c.universe._
     val name = duration match {
       case c.Expr(Ident(n))     ⇒ n
       case c.Expr(Select(_, n)) ⇒ n
-      case c.Expr(x)            ⇒ sys.error(s"requirePositiveOrUndefined cannot be used with argument $x: ${x.getClass}")
+      case c.Expr(x)            ⇒ sys.error(s"requirePositive cannot be used with argument $x: ${x.getClass}")
     }
     val msg: c.Expr[String] = c.Expr(Literal(Constant(s"requirement failed: $name must be > 0 or 'infinite'")))
     reify {

--- a/spray-util/src/main/scala/spray/util/package.scala
+++ b/spray-util/src/main/scala/spray/util/package.scala
@@ -45,10 +45,10 @@ package object util {
     try body catch { case NonFatal(e) ⇒ onError(e) }
 
   /**
-   * Requires that the given duration is greater than Duration.Zero (finite or infinite) or Duration.Undefined.
+   * Requires that the given duration is greater than Duration.Zero (finite or infinite) or Duration.Inf.
    * This implementation is macro-based and only works if the argument is an identifier or member selector.
    */
-  def requirePositiveOrUndefined(duration: Duration): Duration = macro Macros.requirePositiveOrUndefined
+  def requirePositive(duration: Duration): Duration = macro Macros.requirePositive
 
   def actorSystem(implicit refFactory: ActorRefFactory): ExtendedActorSystem =
     refFactory match {

--- a/spray-util/src/main/scala/spray/util/pimps/PimpedConfig.scala
+++ b/spray-util/src/main/scala/spray/util/pimps/PimpedConfig.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration.Duration
 class PimpedConfig(underlying: Config) {
 
   def getDuration(path: String): Duration = underlying.getString(path) match {
-    case "infinite" ⇒ Duration.Undefined
+    case "infinite" ⇒ Duration.Inf
     case x          ⇒ Duration(x)
   }
 


### PR DESCRIPTION
When confugarion is read using the pimped getDuration method the
mapping for "infinite" was Duration.Undefined, but Duration.Undefined !=
Duration.Undefined, which makes comparing any internal settings representation
containing a Duration in a sure failure. Duration.Inf make a lot more sense.
