### PR TITLE
= can: fix PipelineLimiter which only worked for chunked requests, fix #414

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/server/PipelineLimiterSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/server/PipelineLimiterSpec.scala
@@ -24,6 +24,7 @@ import spray.testkit.Specs2PipelineStageTest
 import spray.can.Http
 import spray.can.rendering.ResponsePartRenderingContext
 import spray.http._
+import spray.can.server.RequestParsing.HttpMessageStartEvent
 
 class PipelineLimiterSpec extends Specification with Specs2PipelineStageTest with NoTimeConversions {
   val stage = PipeliningLimiter(2)
@@ -125,8 +126,8 @@ class PipelineLimiterSpec extends Specification with Specs2PipelineStageTest wit
     }
   }
 
-  def request(body: String) = Http.MessageEvent(HttpRequest(entity = body))
-  def requestStart(body: String) = Http.MessageEvent(ChunkedRequestStart(HttpRequest(entity = body)))
+  def request(body: String) = HttpMessageStartEvent(HttpRequest(entity = body), false)
+  def requestStart(body: String) = HttpMessageStartEvent(ChunkedRequestStart(HttpRequest(entity = body)), false)
   def requestChunk(body: String) = Http.MessageEvent(MessageChunk(body))
   def requestEnd(ext: String) = Http.MessageEvent(ChunkedMessageEnd(ext))
 

--- a/spray-can/src/main/scala/spray/can/server/PipeliningLimiter.scala
+++ b/spray-can/src/main/scala/spray/can/server/PipeliningLimiter.scala
@@ -23,7 +23,21 @@ import akka.io.Tcp
 import spray.can.rendering.ResponsePartRenderingContext
 import spray.http._
 import spray.io._
+import RequestParsing._
 
+/**
+ * The PipeliningLimiter tries to limit how much work an external requester can
+ * produce by sending lots of pipelined request directly after each other. It works
+ * by only permitting a limited number of open requests after which 1. incoming data
+ * flow is stopped and 2. incoming requests which are already parsed are put into a queue.
+ *
+ * Some things to keep in mind:
+ *   * It may take quite a while until Tcp.SuspendReading gets to the networking part. In
+ *     this time quite a bit of data may already be in queues to be processed.
+ *   * It doesn't work at all with fast-path because all the request processing is done instantly,
+ *     i.e. during the `eventPL` call in handleEvent the complete request is handled and already sent
+ *     out so that the openRequests counter is never increased.
+ */
 object PipeliningLimiter {
 
   def apply(pipeliningLimit: Int): PipelineStage =
@@ -32,13 +46,13 @@ object PipeliningLimiter {
 
       def apply(context: PipelineContext, commandPL: CPL, eventPL: EPL): Pipelines =
         new Pipelines {
-          var parkedRequestParts = Queue.empty[Http.MessageEvent]
+          var parkedRequestParts = Queue.empty[Event]
           var openRequests = 0
 
           val commandPipeline: CPL = {
-            case x: ResponsePartRenderingContext if x.responsePart.isInstanceOf[HttpMessageEnd] ⇒
+            case cmd @ ResponsePartRenderingContext(_: HttpMessageEnd, _, _, _, _) ⇒
               openRequests -= 1
-              commandPL(x)
+              commandPL(cmd)
               if (parkedRequestParts.nonEmpty) {
                 unparkOneRequest()
                 if (parkedRequestParts.isEmpty) commandPL(Tcp.ResumeReading)
@@ -48,26 +62,28 @@ object PipeliningLimiter {
           }
 
           val eventPipeline: EPL = {
-            case ev: Http.MessageEvent ⇒
-              if (openRequests < pipeliningLimit) {
-                eventPL(ev)
-                if (ev.ev.isInstanceOf[HttpMessageEnd]) openRequests += 1
-              } else {
-                commandPL(Tcp.SuspendReading)
-                parkedRequestParts = parkedRequestParts enqueue ev
-              }
-
-            case ev ⇒ eventPL(ev)
+            case ev @ HttpMessageStartEvent(part, _) ⇒ handleEvent(ev, part)
+            case ev @ Http.MessageEvent(part)        ⇒ handleEvent(ev, part)
+            case ev                                  ⇒ eventPL(ev)
           }
+
+          def handleEvent(ev: Event, part: HttpMessagePart): Unit =
+            if (openRequests < pipeliningLimit) {
+              if (part.isInstanceOf[HttpMessageEnd]) openRequests += 1
+              eventPL(ev)
+            } else {
+              commandPL(Tcp.SuspendReading)
+              parkedRequestParts = parkedRequestParts enqueue ev
+            }
 
           @tailrec
           def unparkOneRequest(): Unit =
             if (!parkedRequestParts.isEmpty) {
               val next = parkedRequestParts.head
               parkedRequestParts = parkedRequestParts.tail
-              eventPL(next)
-              if (next.ev.isInstanceOf[HttpMessageEnd]) openRequests += 1
-              else unparkOneRequest()
+
+              eventPipeline(next)
+              if (openRequests < pipeliningLimit) unparkOneRequest()
             }
         }
     }


### PR DESCRIPTION
Some things to keep in mind:
- It may take quite a while until Tcp.SuspendReading gets to the networking part. In
  this time quite a bit of data may already be in queues to be processed.
- PipelineLimiting doesn't work at all with fast-path because all the request processing is done instantly,
  i.e. during the `eventPL` call in handleEvent the complete request is handled and already sent
  out so that the openRequests counter is never increased.

Facing those problems it may make sense to add a flag to disable pipelining per default with the result that the RequestParser would abort a connection when it receives another request while a previous one isn't finished.
