### PR TITLE
! http: always render '=' in query parameters, fixes #460

### DIFF
--- a/spray-http/src/main/scala/spray/http/Uri.scala
+++ b/spray-http/src/main/scala/spray/http/Uri.scala
@@ -438,7 +438,8 @@ object Uri {
           case Query.Cons(key, value, tail) ⇒
             if (q ne this) r ~~ '&'
             enc(key)
-            if (!value.isEmpty) { r ~~ '='; enc(value) }
+            if (value ne Query.EmptyValue) r ~~ '='
+            enc(value)
             append(tail)
           case Query.Raw(value) ⇒ r ~~ value
         }
@@ -447,6 +448,9 @@ object Uri {
     override def newBuilder: mutable.Builder[(String, String), Query] = Query.newBuilder
   }
   object Query {
+    /** A special empty String value which will be rendered without a '=' after the key. */
+    val EmptyValue: String = new String(Array.empty[Char])
+
     /**
      * Parses the given String into a Query instance.
      * Note that this method will never return Query.Empty, even for the empty String.

--- a/spray-http/src/main/scala/spray/http/parser/UriParser.scala
+++ b/spray-http/src/main/scala/spray/http/parser/UriParser.scala
@@ -302,7 +302,7 @@ private[http] class UriParser(input: ParserInput, charset: Charset, mode: Uri.Pa
     // putting some pressure onto the JVM stack
     def readKVP(): Query = {
       val key = part
-      val value = if (ch('=')) part else ""
+      val value = if (ch('=')) part else Query.EmptyValue
       val tail = if (ch('&')) readKVP() else Query.Empty
       Query.Cons(key, value, tail)
     }

--- a/spray-http/src/test/scala/spray/http/UriSpec.scala
+++ b/spray-http/src/test/scala/spray/http/UriSpec.scala
@@ -361,8 +361,8 @@ class UriSpec extends Specification {
       // queries
       normalize("?") === "?"
       normalize("?key") === "?key"
-      normalize("?key=") === "?key" // our query model cannot discriminate between these two inputs
-      normalize("?key=&a=b") === "?key&a=b" // our query model cannot discriminate between these two inputs
+      normalize("?key=") === "?key="
+      normalize("?key=&a=b") === "?key=&a=b"
       normalize("?key={}&a=[]") === "?key=%7B%7D&a=%5B%5D"
       normalize("?key={}&a=[]", mode = Uri.ParsingMode.Strict) must throwAn[IllegalUriException]
       normalize("?=value") === "?=value"

--- a/spray-httpx/src/test/scala/spray/httpx/marshalling/BasicMarshallersSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/marshalling/BasicMarshallersSpec.scala
@@ -45,7 +45,7 @@ class BasicMarshallersSpec extends Specification {
   "The FormDataMarshaller" should {
     "properly marshal FormData instances to application/x-www-form-urlencoded entity bodies" in {
       marshal(FormData(Map("name" -> "Bob", "pass" -> "hällo", "admin" -> ""))) ===
-        Right(HttpEntity(ContentType(`application/x-www-form-urlencoded`, `UTF-8`), "name=Bob&pass=h%E4llo&admin"))
+        Right(HttpEntity(ContentType(`application/x-www-form-urlencoded`, `UTF-8`), "name=Bob&pass=h%E4llo&admin="))
     }
   }
 


### PR DESCRIPTION
The main reason for this change is that this is the behavior that browsers implement. Missing a clear specification this seems like the best (i.e. most compatible) solution.
