### PR TITLE
! testkit: in RouteTests always convert URIs into absolute ones, fixes #464

### DIFF
--- a/docs/documentation/spray-testkit/index.rst
+++ b/docs/documentation/spray-testkit/index.rst
@@ -58,7 +58,7 @@ The basic structure of a test built with *spray-testkit* is this (expression pla
 
 In this template *REQUEST* is an expression evaluating to an ``HttpRequest`` instance. Since both *RouteTest* traits
 extend the *spray-httpx* :ref:`RequestBuilding` trait you have access to its mini-DSL for convenient and concise request
-construction.
+construction. [1]_
 
 *ROUTE* is an expression evaluating to a *spray-routing* ``Route``. You can specify one inline or simply refer to the
 route structure defined in your service.
@@ -110,6 +110,10 @@ Inspector                                        Description
                                                  ``ChunkedMessageEnd`` response part.
 ================================================ =======================================================================
 
+.. [1] If the request URI is relative it will be made absolute using an implicitly available instance of
+        ``DefaultHostInfo`` whose value is "http://example.com" by default. This mirrors the behavior of *spray-can*
+        which always produces absolute URIs for incoming request based on the request URI and the ``Host``-header of
+        the request. You can customize this behavior by bringing an instance of ``DefaultHostInfo`` into scope.
 
 Sealing Routes
 --------------

--- a/spray-routing-tests/src/test/scala/spray/routing/CachingDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/CachingDirectivesSpec.scala
@@ -44,7 +44,7 @@ class CachingDirectivesSpec extends RoutingSpec with CachingDirectives {
     }
   }
   def prime(route: Route) = {
-    route(RequestContext(HttpRequest(), system.deadLetters, Uri.Path.Empty).withDefaultSender(system.deadLetters))
+    route(RequestContext(HttpRequest(uri = Uri("http://example.com/")), system.deadLetters, Uri.Path.Empty).withDefaultSender(system.deadLetters))
     route
   }
 

--- a/spray-routing-tests/src/test/scala/spray/routing/DebuggingDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/DebuggingDirectivesSpec.scala
@@ -43,7 +43,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
     "produce a proper log message for incoming requests" in {
       Get("/hello") ~> logRequest("1") { completeOk } ~> check {
         response === Ok
-        debugMsg === "1: HttpRequest(GET,/hello,List(),EmptyEntity,HTTP/1.1)\n"
+        debugMsg === "1: HttpRequest(GET,http://example.com/hello,List(),EmptyEntity,HTTP/1.1)\n"
       }
     }
   }
@@ -64,7 +64,7 @@ class DebuggingDirectivesSpec extends RoutingSpec {
       Get("/hello") ~> logRequestResponse("3") { completeOk } ~> check {
         response === Ok
         debugMsg === """|3: Response for
-                        |  Request : HttpRequest(GET,/hello,List(),EmptyEntity,HTTP/1.1)
+                        |  Request : HttpRequest(GET,http://example.com/hello,List(),EmptyEntity,HTTP/1.1)
                         |  Response: HttpResponse(200 OK,EmptyEntity,List(),HTTP/1.1)
                         |""".stripMargin.replace(EOL, "\n")
       }


### PR DESCRIPTION
This is to mirror the behavior of spray-can / spray-servlet which make request URIs always absolute (using the supplied `Host` header).
