### PR TITLE
+ caching: add a size method to Cache[V]

### DIFF
--- a/spray-caching/src/main/scala/spray/caching/Cache.scala
+++ b/spray-caching/src/main/scala/spray/caching/Cache.scala
@@ -66,6 +66,14 @@ trait Cache[V] { cache ⇒
    * Clears the cache by removing all entries.
    */
   def clear()
+
+  /**
+   * Returns the upper bound for the number of currently cached entries.
+   * Note that this number might not reflect the exact number of active, unexpired
+   * cache entries, since expired entries are only evicted upon next access
+   * (or by being thrown out by a capacity constraint).
+   */
+  def size: Int
 }
 
 class ValueMagnet[V](val future: Future[V])

--- a/spray-caching/src/main/scala/spray/caching/LruCache.scala
+++ b/spray-caching/src/main/scala/spray/caching/LruCache.scala
@@ -80,6 +80,8 @@ final class SimpleLruCache[V](val maxCapacity: Int, val initialCapacity: Int) ex
   def remove(key: Any) = Option(store.remove(key))
 
   def clear(): Unit = { store.clear() }
+
+  def size = store.size
 }
 
 /**
@@ -159,6 +161,8 @@ final class ExpiringLruCache[V](maxCapacity: Long, initialCapacity: Int,
   }
 
   def clear(): Unit = { store.clear() }
+
+  def size = store.size
 
   private def isAlive(entry: Entry[V]) = {
     val now = System.currentTimeMillis

--- a/spray-caching/src/test/scala/spray/caching/ExpiringLruCacheSpec.scala
+++ b/spray-caching/src/test/scala/spray/caching/ExpiringLruCacheSpec.scala
@@ -33,17 +33,20 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
   "An LruCache" should {
     "be initially empty" in {
       lruCache().store.toString === "{}"
+      lruCache().size === 0
     }
     "store uncached values" in {
       val cache = lruCache[String]()
       cache(1)("A").await === "A"
       cache.store.toString === "{1=A}"
+      cache.size === 1
     }
     "return stored values upon cache hit on existing values" in {
       val cache = lruCache[String]()
       cache(1)("A").await === "A"
       cache(1)(failure("Cached expression was evaluated despite a cache hit"): String).await === "A"
       cache.store.toString === "{1=A}"
+      cache.size === 1
     }
     "return Futures on uncached values during evaluation and replace these with the value afterwards" in {
       val cache = lruCache[String]()
@@ -60,6 +63,7 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
       future1.await === "A"
       future2.await === "A"
       cache.store.toString === "{1=A}"
+      cache.size === 1
     }
     "properly limit capacity" in {
       val cache = lruCache[String](maxCapacity = 3)
@@ -70,6 +74,7 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
       cache(4)("D")
       Thread.sleep(10)
       cache.store.toString === "{2=B, 3=C, 4=D}"
+      cache.size === 3
     }
     "expire old entries" in {
       val cache = lruCache[String](timeToLive = 75 millis span)
@@ -77,10 +82,10 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
       cache(2)("B").await === "B"
       Thread.sleep(50)
       cache(3)("C").await === "C"
-      cache.store.size === 3
+      cache.size === 3
       Thread.sleep(50)
       cache.get(2) must beNone // removed on request
-      cache.store.size === 2 // expired entry 1 still there
+      cache.size === 2 // expired entry 1 still there
       cache.get(1) must beNone // but not retrievable anymore
     }
     "not cache exceptions" in {


### PR DESCRIPTION
Fix for #476

I thought about starting a discussion about whether the meaning of "size" might be slightly unclear in the context of the ExpiringLruCache, since it will count expired keys too, but the change was so simple that I thought I might as well just implement it and see what you guys say :)
