### PR TITLE
= caching: Upgrade to concurrentlinkedhashmap 1.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
   val specs2        = "org.specs2"                              %%  "specs2"                      % "1.14"
   val sprayJson     = "io.spray"                                %%  "spray-json"                  % "1.2.5"
   val twirlApi      = "io.spray"                                %%  "twirl-api"                   % "0.6.2"
-  val clHashMap     = "com.googlecode.concurrentlinkedhashmap"  %   "concurrentlinkedhashmap-lru" % "1.3.2"
+  val clHashMap     = "com.googlecode.concurrentlinkedhashmap"  %   "concurrentlinkedhashmap-lru" % "1.4"
   val jettyWebApp   = "org.eclipse.jetty"                       %   "jetty-webapp"                % "8.1.11.v20130520"
   val servlet30     = "org.eclipse.jetty.orbit"                 %   "javax.servlet"               % "3.0.0.v201112011016" artifacts Artifact("javax.servlet", "jar", "jar")
   val logback       = "ch.qos.logback"                          %   "logback-classic"             % "1.0.13"

--- a/spray-caching/src/test/scala/spray/caching/ExpiringLruCacheSpec.scala
+++ b/spray-caching/src/test/scala/spray/caching/ExpiringLruCacheSpec.scala
@@ -66,7 +66,7 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
       cache(1)("A").await === "A"
       cache(2)(Future.successful("B")).await === "B"
       cache(3)("C").await === "C"
-      cache.store.toString === "{2=B, 1=A, 3=C}"
+      cache.store.toString === "{1=A, 2=B, 3=C}"
       cache(4)("D")
       Thread.sleep(10)
       cache.store.toString === "{2=B, 3=C, 4=D}"
@@ -94,7 +94,7 @@ class ExpiringLruCacheSpec extends Specification with NoTimeConversions {
       cache(2)("B").await === "B"
       cache(3)("C").await === "C"
       cache(1)("").await === "A" // refresh
-      cache.store.toString === "{2=B, 1=A, 3=C}"
+      cache.store.toString === "{1=A, 2=B, 3=C}"
     }
     "be thread-safe" in {
       val cache = lruCache[Int](maxCapacity = 1000)


### PR DESCRIPTION
Fixes #450

The upgrade was relatively simple. I had to adjust a few values in the test because CLHM 1.4 uses a slightly different backing map which changes the order of values in the toString output but (it seems) in a predictable way.
