### PR TITLE
= io: port over changes from upstream akka-io (as of EOB 2013-08-27)

### DIFF
--- a/spray-io/src/main/scala/akka/io/Inet.scala
+++ b/spray-io/src/main/scala/akka/io/Inet.scala
@@ -31,7 +31,7 @@ object Inet {
   object SO {
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_RCVBUF option
+     * [[akka.io.Inet.SocketOption]] to set the SO_RCVBUF option
      *
      * For more information see [[java.net.Socket.setReceiveBufferSize]]
      */
@@ -45,7 +45,7 @@ object Inet {
     // server socket options
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to enable or disable SO_REUSEADDR
+     * [[akka.io.Inet.SocketOption]] to enable or disable SO_REUSEADDR
      *
      * For more information see [[java.net.Socket.setReuseAddress]]
      */
@@ -56,7 +56,7 @@ object Inet {
     }
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_SNDBUF option.
+     * [[akka.io.Inet.SocketOption]] to set the SO_SNDBUF option.
      *
      * For more information see [[java.net.Socket.setSendBufferSize]]
      */
@@ -66,7 +66,7 @@ object Inet {
     }
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the traffic class or
+     * [[akka.io.Inet.SocketOption]] to set the traffic class or
      * type-of-service octet in the IP header for packets sent from this
      * socket.
      *
@@ -81,28 +81,28 @@ object Inet {
 
   trait SoForwarders {
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_RCVBUF option
+     * [[akka.io.Inet.SocketOption]] to set the SO_RCVBUF option
      *
      * For more information see [[java.net.Socket.setReceiveBufferSize]]
      */
     val ReceiveBufferSize = SO.ReceiveBufferSize
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to enable or disable SO_REUSEADDR
+     * [[akka.io.Inet.SocketOption]] to enable or disable SO_REUSEADDR
      *
      * For more information see [[java.net.Socket.setReuseAddress]]
      */
     val ReuseAddress = SO.ReuseAddress
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_SNDBUF option.
+     * [[akka.io.Inet.SocketOption]] to set the SO_SNDBUF option.
      *
      * For more information see [[java.net.Socket.setSendBufferSize]]
      */
     val SendBufferSize = SO.SendBufferSize
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the traffic class or
+     * [[akka.io.Inet.SocketOption]] to set the traffic class or
      * type-of-service octet in the IP header for packets sent from this
      * socket.
      *
@@ -114,28 +114,28 @@ object Inet {
   trait SoJavaFactories {
     import SO._
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_RCVBUF option
+     * [[akka.io.Inet.SocketOption]] to set the SO_RCVBUF option
      *
      * For more information see [[java.net.Socket.setReceiveBufferSize]]
      */
     def receiveBufferSize(size: Int) = ReceiveBufferSize(size)
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to enable or disable SO_REUSEADDR
+     * [[akka.io.Inet.SocketOption]] to enable or disable SO_REUSEADDR
      *
      * For more information see [[java.net.Socket.setReuseAddress]]
      */
     def reuseAddress(on: Boolean) = ReuseAddress(on)
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the SO_SNDBUF option.
+     * [[akka.io.Inet.SocketOption]] to set the SO_SNDBUF option.
      *
      * For more information see [[java.net.Socket.setSendBufferSize]]
      */
     def sendBufferSize(size: Int) = SendBufferSize(size)
 
     /**
-     * [[akka.io.Tcp.SocketOption]] to set the traffic class or
+     * [[akka.io.Inet.SocketOption]] to set the traffic class or
      * type-of-service octet in the IP header for packets sent from this
      * socket.
      *

--- a/spray-io/src/main/scala/akka/io/Tcp.scala
+++ b/spray-io/src/main/scala/akka/io/Tcp.scala
@@ -23,15 +23,15 @@ import akka.actor._
  * stable and ready for production use.
  *
  * For a full description of the design and philosophy behind this IO
- * implementation please refer to {@see <a href="http://doc.akka.io/">the Akka online documentation</a>}.
+ * implementation please refer to <a href="http://doc.akka.io/">the Akka online documentation</a>.
  *
- * In order to open an outbound connection send a [[Tcp.Connect]] message
- * to the [[TcpExt#manager]].
+ * In order to open an outbound connection send a [[akka.io.Tcp.Connect]] message
+ * to the [[akka.io.TcpExt#manager]].
  *
- * In order to start listening for inbound connetions send a [[Tcp.Bind]]
- * message to the [[TcpExt#manager]].
+ * In order to start listening for inbound connetions send a [[akka.io.Tcp.Bind]]
+ * message to the [[akka.io.TcpExt#manager]].
  *
- * The Java API for generating TCP commands is available at [[TcpMessage]].
+ * The Java API for generating TCP commands is available at [[akka.io.TcpMessage]].
  */
 object Tcp extends ExtensionKey[TcpExt] {
 
@@ -43,7 +43,7 @@ object Tcp extends ExtensionKey[TcpExt] {
   /**
    * Scala API: this object contains all applicable socket options for TCP.
    *
-   * For the Java API see [[TcpSO]].
+   * For the Java API see [[akka.io.TcpSO]].
    */
   object SO extends Inet.SoForwarders {
 
@@ -86,7 +86,7 @@ object Tcp extends ExtensionKey[TcpExt] {
   }
 
   /**
-   * The common interface for [[Command]] and [[Event]].
+   * The common interface for [[akka.io.Command]] and [[akka.io.Tcp.Event]].
    */
   sealed trait Message
 
@@ -101,13 +101,13 @@ object Tcp extends ExtensionKey[TcpExt] {
 
   /**
    * The Connect message is sent to the TCP manager actor, which is obtained via
-   * [[TcpExt#manager]]. Either the manager replies with a [[CommandFailed]]
-   * or the actor handling the new connection replies with a [[Connected]]
+   * [[akka.io.Tcp.TcpExt#manager]]. Either the manager replies with a [[akka.io.Tcp.CommandFailed]]
+   * or the actor handling the new connection replies with a [[akka.io.Tcp.Connected]]
    * message.
    *
    * @param remoteAddress is the address to connect to
    * @param localAddress optionally specifies a specific address to bind to
-   * @param options Please refer to the [[SO]] object for a list of all supported options.
+   * @param options Please refer to the [[akka.io.Tcp.SO]] object for a list of all supported options.
    */
   case class Connect(remoteAddress: InetSocketAddress,
                      localAddress: Option[InetSocketAddress] = None,
@@ -116,22 +116,22 @@ object Tcp extends ExtensionKey[TcpExt] {
 
   /**
    * The Bind message is send to the TCP manager actor, which is obtained via
-   * [[TcpExt#manager]] in order to bind to a listening socket. The manager
-   * replies either with a [[CommandFailed]] or the actor handling the listen
-   * socket replies with a [[Bound]] message. If the local port is set to 0 in
-   * the Bind message, then the [[Bound]] message should be inspected to find
+   * [[akka.io.Tcp.TcpExt#manager]] in order to bind to a listening socket. The manager
+   * replies either with a [[akka.io.Tcp.CommandFailed]] or the actor handling the listen
+   * socket replies with a [[akka.io.Tcp.Bound]] message. If the local port is set to 0 in
+   * the Bind message, then the [[akka.io.Tcp.Bound]] message should be inspected to find
    * the actual port which was bound to.
    *
    * @param handler The actor which will receive all incoming connection requests
-   *                in the form of [[Connected]] messages.
+   *                in the form of [[akka.io.Tcp.Connected]] messages.
    *
    * @param localAddress The socket address to bind to; use port zero for
-   *                automatic assignment (i.e. an ephemeral port, see [[Bound]])
+   *                automatic assignment (i.e. an ephemeral port, see [[akka.io.Tcp.Bound]])
    *
    * @param backlog This specifies the number of unaccepted connections the O/S
    *                kernel will hold for this port before refusing connections.
    *
-   * @param options Please refer to the [[SO]] object for a list of all supported options.
+   * @param options Please refer to the [[akka.io.Tcp.SO]] object for a list of all supported options.
    */
   case class Bind(handler: ActorRef,
                   localAddress: InetSocketAddress,
@@ -140,7 +140,7 @@ object Tcp extends ExtensionKey[TcpExt] {
 
   /**
    * This message must be sent to a TCP connection actor after receiving the
-   * [[Connected]] message. The connection will not read any data from the
+   * [[akka.io.Tcp.Connected]] message. The connection will not read any data from the
    * socket until this message is received, because this message defines the
    * actor which will receive all inbound data.
    *
@@ -149,19 +149,19 @@ object Tcp extends ExtensionKey[TcpExt] {
    *
    * @param keepOpenOnPeerClosed If this is set to true then the connection
    *                is not automatically closed when the peer closes its half,
-   *                requiring an explicit [[Closed]] from our side when finished.
+   *                requiring an explicit [[akka.io.Tcp.Closed]] from our side when finished.
    *
    * @param useResumeWriting If this is set to true then the connection actor
-   *                will refuse all further writes after issuing a [[CommandFailed]]
-   *                notification until [[ResumeWriting]] is received. This can
+   *                will refuse all further writes after issuing a [[akka.io.Tcp.CommandFailed]]
+   *                notification until [[akka.io.Tcp.ResumeWriting]] is received. This can
    *                be used to implement NACK-based write backpressure.
    */
   case class Register(handler: ActorRef, keepOpenOnPeerClosed: Boolean = false, useResumeWriting: Boolean = true) extends Command
 
   /**
    * In order to close down a listening socket, send this message to that socket’s
-   * actor (that is the actor which previously had sent the [[Bound]] message). The
-   * listener socket actor will reply with a [[Unbound]] message.
+   * actor (that is the actor which previously had sent the [[akka.io.Tcp.Bound]] message). The
+   * listener socket actor will reply with a [[akka.io.Tcp.Unbound]] message.
    */
   case object Unbind extends Command
 
@@ -179,7 +179,7 @@ object Tcp extends ExtensionKey[TcpExt] {
   /**
    * A normal close operation will first flush pending writes and then close the
    * socket. The sender of this command and the registered handler for incoming
-   * data will both be notified once the socket is closed using a [[Closed]]
+   * data will both be notified once the socket is closed using a [[akka.io.Tcp.Closed]]
    * message.
    */
   case object Close extends CloseCommand {
@@ -194,7 +194,7 @@ object Tcp extends ExtensionKey[TcpExt] {
    * A confirmed close operation will flush pending writes and half-close the
    * connection, waiting for the peer to close the other half. The sender of this
    * command and the registered handler for incoming data will both be notified
-   * once the socket is closed using a [[ConfirmedClosed]] message.
+   * once the socket is closed using a [[akka.io.Tcp.ConfirmedClosed]] message.
    */
   case object ConfirmedClose extends CloseCommand {
     /**
@@ -209,7 +209,7 @@ object Tcp extends ExtensionKey[TcpExt] {
    * command to the O/S kernel which should result in a TCP_RST packet being sent
    * to the peer. The sender of this command and the registered handler for
    * incoming data will both be notified once the socket is closed using a
-   * [[Aborted]] message.
+   * [[akka.io.Tcp.Aborted]] message.
    */
   case object Abort extends CloseCommand {
     /**
@@ -220,21 +220,21 @@ object Tcp extends ExtensionKey[TcpExt] {
   }
 
   /**
-   * Each [[WriteCommand]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[WriteCommand#ack]]
+   * Each [[akka.io.Tcp.WriteCommand]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[akka.io.Tcp.WriteCommand#ack]]
    * must be set to an instance of this class. The token contained within can be used
-   * to recognize which write failed when receiving a [[CommandFailed]] message.
+   * to recognize which write failed when receiving a [[akka.io.Tcp.CommandFailed]] message.
    */
   case class NoAck(token: Any) extends Event
 
   /**
-   * Default [[NoAck]] instance which is used when no acknowledgment information is
+   * Default [[akka.io.Tcp.NoAck]] instance which is used when no acknowledgment information is
    * explicitly provided. Its “token” is `null`.
    */
   object NoAck extends NoAck(null)
 
   /**
-   * Common interface for all write commands, currently [[Write]] and [[WriteFile]].
+   * Common interface for all write commands, currently [[akka.io.Tcp.Write]] and [[akka.io.Tcp.WriteFile]].
    */
   sealed trait WriteCommand extends Command {
     require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
@@ -246,16 +246,16 @@ object Tcp extends ExtensionKey[TcpExt] {
 
     /**
      * An acknowledgment is only sent if this write command “wants an ack”, which is
-     * equivalent to the [[#ack]] token not being a of type [[NoAck]].
+     * equivalent to the [[akka.io.Tcp.#ack]] token not being a of type [[akka.io.Tcp.NoAck]].
      */
     def wantsAck: Boolean = !ack.isInstanceOf[NoAck]
   }
 
   /**
    * Write data to the TCP connection. If no ack is needed use the special
-   * `NoAck` object. The connection actor will reply with a [[CommandFailed]]
-   * message if the write could not be enqueued. If [[WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[WriteCommand#ack]]
+   * `NoAck` object. The connection actor will reply with a [[akka.io.Tcp.CommandFailed]]
+   * message if the write could not be enqueued. If [[akka.io.Tcp.WriteCommand#wantsAck]]
+   * returns true, the connection actor will reply with the supplied [[akka.io.Tcp.WriteCommand#ack]]
    * token once the write has been successfully enqueued to the O/S kernel.
    * <b>Note that this does not in any way guarantee that the data will be
    * or have been sent!</b> Unfortunately there is no way to determine whether
@@ -280,9 +280,9 @@ object Tcp extends ExtensionKey[TcpExt] {
 
   /**
    * Write `count` bytes starting at `position` from file at `filePath` to the connection.
-   * The count must be > 0. The connection actor will reply with a [[CommandFailed]]
-   * message if the write could not be enqueued. If [[WriteCommand#wantsAck]]
-   * returns true, the connection actor will reply with the supplied [[WriteCommand#ack]]
+   * The count must be > 0. The connection actor will reply with a [[akka.io.Tcp.CommandFailed]]
+   * message if the write could not be enqueued. If [[akka.io.Tcp.WriteCommand#wantsAck]]
+   * returns true, the connection actor will reply with the supplied [[akka.io.Tcp.WriteCommand#ack]]
    * token once the write has been successfully enqueued to the O/S kernel.
    * <b>Note that this does not in any way guarantee that the data will be
    * or have been sent!</b> Unfortunately there is no way to determine whether
@@ -294,23 +294,23 @@ object Tcp extends ExtensionKey[TcpExt] {
   }
 
   /**
-   * When `useResumeWriting` is in effect as was indicated in the [[Register]] message
+   * When `useResumeWriting` is in effect as was indicated in the [[akka.io.Tcp.Register]] message
    * then this command needs to be sent to the connection actor in order to re-enable
-   * writing after a [[CommandFailed]] event. All [[WriteCommand]] processed by the
-   * connection actor between the first [[CommandFailed]] and subsequent reception of
-   * this message will also be rejected with [[CommandFailed]].
+   * writing after a [[akka.io.Tcp.CommandFailed]] event. All [[akka.io.Tcp.WriteCommand]] processed by the
+   * connection actor between the first [[akka.io.Tcp.CommandFailed]] and subsequent reception of
+   * this message will also be rejected with [[akka.io.Tcp.CommandFailed]].
    */
   case object ResumeWriting extends Command
 
   /**
    * Sending this command to the connection actor will disable reading from the TCP
    * socket. TCP flow-control will then propagate backpressure to the sender side
-   * as buffers fill up on either end. To re-enable reading send [[ResumeReading]].
+   * as buffers fill up on either end. To re-enable reading send [[akka.io.Tcp.ResumeReading]].
    */
   case object SuspendReading extends Command
 
   /**
-   * This command needs to be sent to the connection actor after a [[SuspendReading]]
+   * This command needs to be sent to the connection actor after a [[akka.io.Tcp.SuspendReading]]
    * command in order to resume reading from the socket.
    */
   case object ResumeReading extends Command
@@ -323,14 +323,14 @@ object Tcp extends ExtensionKey[TcpExt] {
 
   /**
    * Whenever data are read from a socket they will be transferred within this
-   * class to the handler actor which was designated in the [[Register]] message.
+   * class to the handler actor which was designated in the [[akka.io.Tcp.Register]] message.
    */
   case class Received(data: ByteString) extends Event
 
   /**
-   * The connection actor sends this message either to the sender of a [[Connect]]
+   * The connection actor sends this message either to the sender of a [[akka.io.Tcp.Connect]]
    * command (for outbound) or to the handler for incoming connections designated
-   * in the [[Bind]] message. The connection is characterized by the `remoteAddress`
+   * in the [[akka.io.Tcp.Bind]] message. The connection is characterized by the `remoteAddress`
    * and `localAddress` TCP endpoints.
    */
   case class Connected(remoteAddress: InetSocketAddress, localAddress: InetSocketAddress) extends Event
@@ -342,24 +342,24 @@ object Tcp extends ExtensionKey[TcpExt] {
   case class CommandFailed(cmd: Command) extends Event
 
   /**
-   * When `useResumeWriting` is in effect as indicated in the [[Register]] message,
-   * the [[ResumeWriting]] command will be acknowledged by this message type, upon
+   * When `useResumeWriting` is in effect as indicated in the [[akka.io.Tcp.Register]] message,
+   * the [[akka.io.Tcp.ResumeWriting]] command will be acknowledged by this message type, upon
    * which it is safe to send at least one write. This means that all writes preceding
-   * the first [[CommandFailed]] message have been enqueued to the O/S kernel at this
+   * the first [[akka.io.Tcp.CommandFailed]] message have been enqueued to the O/S kernel at this
    * point.
    */
   sealed trait WritingResumed extends Event
   case object WritingResumed extends WritingResumed
 
   /**
-   * The sender of a [[Bind]] command will—in case of success—receive confirmation
+   * The sender of a [[akka.io.Tcp.Bind]] command will—in case of success—receive confirmation
    * in this form. If the bind address indicated a 0 port number, then the contained
    * `localAddress` can be used to find out which port was automatically assigned.
    */
   case class Bound(localAddress: InetSocketAddress) extends Event
 
   /**
-   * The sender of an [[Unbind]] command will receive confirmation through this
+   * The sender of an [[akka.io.Tcp.Unbind]] command will receive confirmation through this
    * message once the listening socket has been closed.
    */
   sealed trait Unbound extends Event
@@ -371,17 +371,17 @@ object Tcp extends ExtensionKey[TcpExt] {
    */
   sealed trait ConnectionClosed extends Event {
     /**
-     * `true` iff the connection has been closed in response to an [[Abort]] command.
+     * `true` iff the connection has been closed in response to an [[akka.io.Tcp.Abort]] command.
      */
     def isAborted: Boolean = false
     /**
      * `true` iff the connection has been fully closed in response to a
-     * [[ConfirmedClose]] command.
+     * [[akka.io.Tcp.ConfirmedClose]] command.
      */
     def isConfirmed: Boolean = false
     /**
      * `true` iff the connection has been closed by the peer; in case
-     * `keepOpenOnPeerClosed` is in effect as per the [[Register]] command,
+     * `keepOpenOnPeerClosed` is in effect as per the [[akka.io.Tcp.Register]] command,
      * this connection’s reading half is now closed.
      */
     def isPeerClosed: Boolean = false
@@ -396,18 +396,18 @@ object Tcp extends ExtensionKey[TcpExt] {
     def getErrorCause: String = null
   }
   /**
-   * The connection has been closed normally in response to a [[Close]] command.
+   * The connection has been closed normally in response to a [[akka.io.Tcp.Close]] command.
    */
   case object Closed extends ConnectionClosed
   /**
-   * The connection has been aborted in response to an [[Abort]] command.
+   * The connection has been aborted in response to an [[akka.io.Tcp.Abort]] command.
    */
   case object Aborted extends ConnectionClosed {
     override def isAborted = true
   }
   /**
    * The connection has been half-closed by us and then half-close by the peer
-   * in response to a [[ConfirmedClose]] command.
+   * in response to a [[akka.io.Tcp.ConfirmedClose]] command.
    */
   case object ConfirmedClosed extends ConnectionClosed {
     override def isConfirmed = true

--- a/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -37,48 +37,54 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
   channelRegistry.register(channel, SelectionKey.OP_CONNECT)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied
 
+  private def stop(): Unit = stopWith(CloseInformation(Set(commander), connect.failureMessage))
+
+  private def reportConnectFailure(thunk: ⇒ Unit): Unit = {
+    try {
+      thunk
+    } catch {
+      case e: IOException ⇒
+        log.debug("Could not establish connection to [{}] due to {}", remoteAddress, e)
+        stop()
+    }
+  }
+
   def receive: Receive = {
     case registration: ChannelRegistration ⇒
       log.debug("Attempting connection to [{}]", remoteAddress)
-      if (channel.connect(remoteAddress))
-        completeConnect(registration, commander, options)
-      else
-        context.become(connecting(registration, commander, options, tcp.Settings.FinishConnectRetries))
+      reportConnectFailure {
+        if (channel.connect(remoteAddress))
+          completeConnect(registration, commander, options)
+        else
+          context.become(connecting(registration, commander, options, tcp.Settings.FinishConnectRetries))
+      }
   }
 
   def connecting(registration: ChannelRegistration, commander: ActorRef,
                  options: immutable.Traversable[SocketOption], remainingFinishConnectRetries: Int): Receive = {
-    def stop(): Unit = stopWith(CloseInformation(Set(commander), connect.failureMessage))
-
-    {
-      case ChannelConnectable ⇒
-        try {
-          if (channel.finishConnect()) {
-            if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
-            log.debug("Connection established to [{}]", remoteAddress)
-            completeConnect(registration, commander, options)
+    case ChannelConnectable ⇒
+      reportConnectFailure {
+        if (channel.finishConnect()) {
+          if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
+          log.debug("Connection established to [{}]", remoteAddress)
+          completeConnect(registration, commander, options)
+        } else {
+          if (remainingFinishConnectRetries > 0) {
+            context.system.scheduler.scheduleOnce(1.millisecond) {
+              channelRegistry.register(channel, SelectionKey.OP_CONNECT)
+            }(context.dispatcher)
+            context.become(connecting(registration, commander, options, remainingFinishConnectRetries - 1))
           } else {
-            if (remainingFinishConnectRetries > 0) {
-              context.system.scheduler.scheduleOnce(1.millisecond) {
-                channelRegistry.register(channel, SelectionKey.OP_CONNECT)
-              }(context.dispatcher)
-              context.become(connecting(registration, commander, options, remainingFinishConnectRetries - 1))
-            } else {
-              log.debug("Could not establish connection because finishConnect " +
-                "never returned true (consider increasing akka.io.tcp.finish-connect-retries)")
-              stop()
-            }
-          }
-        } catch {
-          case e: IOException ⇒
-            log.debug("Could not establish connection due to {}", e)
+            log.debug("Could not establish connection because finishConnect " +
+              "never returned true (consider increasing akka.io.tcp.finish-connect-retries)")
             stop()
+          }
         }
+      }
 
-      case ReceiveTimeout ⇒
-        if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
-        log.debug("Connect timeout expired, could not establish connection to {}", remoteAddress)
-        stop()
-    }
+    case ReceiveTimeout ⇒
+      if (timeout.isDefined) context.setReceiveTimeout(Duration.Undefined) // Clear the timeout
+      log.debug("Connect timeout expired, could not establish connection to {}", remoteAddress)
+      stop()
   }
 }

--- a/spray-io/src/main/scala/akka/io/Udp.scala
+++ b/spray-io/src/main/scala/akka/io/Udp.scala
@@ -22,12 +22,12 @@ import akka.actor._
  *
  * This extension implements the connectionless UDP protocol without
  * calling `connect` on the underlying sockets, i.e. without restricting
- * from whom data can be received. For “connected” UDP mode see [[UdpConnected]].
+ * from whom data can be received. For “connected” UDP mode see [[akka.io.UdpConnected]].
  *
  * For a full description of the design and philosophy behind this IO
- * implementation please refer to {@see <a href="http://doc.akka.io/">the Akka online documentation</a>}.
+ * implementation please refer to <a href="http://doc.akka.io/">the Akka online documentation</a>.
  *
- * The Java API for generating UDP commands is available at [[UdpMessage]].
+ * The Java API for generating UDP commands is available at [[akka.io.UdpMessage]].
  */
 object Udp extends ExtensionKey[UdpExt] {
 
@@ -37,7 +37,7 @@ object Udp extends ExtensionKey[UdpExt] {
   override def get(system: ActorSystem): UdpExt = super.get(system)
 
   /**
-   * The common interface for [[Command]] and [[Event]].
+   * The common interface for [[akka.io.Udp.Command]] and [[akka.io.Udp.Event]].
    */
   sealed trait Message
 
@@ -49,34 +49,34 @@ object Udp extends ExtensionKey[UdpExt] {
   }
 
   /**
-   * Each [[Send]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[Send#ack]]
+   * Each [[akka.io.Udp.Send]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[akka.io.Udp.Send#ack]]
    * must be set to an instance of this class. The token contained within can be used
-   * to recognize which write failed when receiving a [[CommandFailed]] message.
+   * to recognize which write failed when receiving a [[akka.io.Udp.CommandFailed]] message.
    */
   case class NoAck(token: Any) extends Event
 
   /**
-   * Default [[NoAck]] instance which is used when no acknowledgment information is
+   * Default [[akka.io.Udp.NoAck]] instance which is used when no acknowledgment information is
    * explicitly provided. Its “token” is `null`.
    */
   object NoAck extends NoAck(null)
 
   /**
    * This message is understood by the “simple sender” which can be obtained by
-   * sending the [[SimpleSender]] query to the [[UdpExt#manager]] as well as by
-   * the listener actors which are created in response to [[Bind]]. It will send
+   * sending the [[akka.io.Udp.SimpleSender]] query to the [[akka.io.Udp.UdpExt#manager]] as well as by
+   * the listener actors which are created in response to [[akka.io.Udp.Bind]]. It will send
    * the given payload data as one UDP datagram to the given target address. The
-   * UDP actor will respond with [[CommandFailed]] if the send could not be
+   * UDP actor will respond with [[akka.io.Udp.CommandFailed]] if the send could not be
    * enqueued to the O/S kernel because the send buffer was full. If the given
-   * `ack` is not of type [[NoAck]] the UDP actor will reply with the given
+   * `ack` is not of type [[akka.io.Udp.NoAck]] the UDP actor will reply with the given
    * object as soon as the datagram has been successfully enqueued to the O/S
    * kernel.
    *
    * The sending UDP socket’s address belongs to the “simple sender” which does
    * not handle inbound datagrams and sends from an ephemeral port; therefore
    * sending using this mechanism is not suitable if replies are expected, use
-   * [[Bind]] in that case.
+   * [[akka.io.Udp.Bind]] in that case.
    */
   case class Send(payload: ByteString, target: InetSocketAddress, ack: Event) extends Command {
     require(ack != null, "ack must be non-null. Use NoAck if you don't want acks.")
@@ -88,25 +88,25 @@ object Udp extends ExtensionKey[UdpExt] {
   }
 
   /**
-   * Send this message to the [[UdpExt#manager]] in order to bind to the given
+   * Send this message to the [[akka.io.Udp.UdpExt#manager]] in order to bind to the given
    * local port (or an automatically assigned one if the port number is zero).
-   * The listener actor for the newly bound port will reply with a [[Bound]]
-   * message, or the manager will reply with a [[CommandFailed]] message.
+   * The listener actor for the newly bound port will reply with a [[akka.io.Udp.Bound]]
+   * message, or the manager will reply with a [[akka.io.Udp.CommandFailed]] message.
    */
   case class Bind(handler: ActorRef,
                   localAddress: InetSocketAddress,
                   options: immutable.Traversable[SocketOption] = Nil) extends Command
 
   /**
-   * Send this message to the listener actor that previously sent a [[Bound]]
+   * Send this message to the listener actor that previously sent a [[akka.io.Udp.Bound]]
    * message in order to close the listening socket. The recipient will reply
-   * with an [[Unbound]] message.
+   * with an [[akka.io.Udp.Unbound]] message.
    */
   case object Unbind extends Command
 
   /**
    * Retrieve a reference to a “simple sender” actor of the UDP extension.
-   * The newly created “simple sender” will reply with the [[SimpleSenderReady]] notification.
+   * The newly created “simple sender” will reply with the [[akka.io.Udp.SimpleSenderReady]] notification.
    *
    * The “simple sender” is a convenient service for being able to send datagrams
    * when the originating address is meaningless, i.e. when no reply is expected.
@@ -118,16 +118,16 @@ object Udp extends ExtensionKey[UdpExt] {
   object SimpleSender extends SimpleSender(Nil)
 
   /**
-   * Send this message to a listener actor (which sent a [[Bound]] message) to
+   * Send this message to a listener actor (which sent a [[akka.io.Udp.Bound]] message) to
    * have it stop reading datagrams from the network. If the O/S kernel’s receive
    * buffer runs full then subsequent datagrams will be silently discarded.
-   * Re-enable reading from the socket using the [[ResumeReading]] command.
+   * Re-enable reading from the socket using the [[akka.io.Udp.ResumeReading]] command.
    */
   case object SuspendReading extends Command
 
   /**
    * This message must be sent to the listener actor to re-enable reading from
-   * the socket after a [[SuspendReading]] command.
+   * the socket after a [[akka.io.Udp.SuspendReading]] command.
    */
   case object ResumeReading extends Command
 
@@ -138,7 +138,7 @@ object Udp extends ExtensionKey[UdpExt] {
 
   /**
    * When a listener actor receives a datagram from its socket it will send
-   * it to the handler designated in the [[Bind]] message using this message type.
+   * it to the handler designated in the [[akka.io.Udp.Bind]] message using this message type.
    */
   case class Received(data: ByteString, sender: InetSocketAddress) extends Event
 
@@ -149,20 +149,20 @@ object Udp extends ExtensionKey[UdpExt] {
   case class CommandFailed(cmd: Command) extends Event
 
   /**
-   * This message is sent by the listener actor in response to a [[Bind]] command.
+   * This message is sent by the listener actor in response to a [[akka.io.Udp.Bind]] command.
    * If the address to bind to specified a port number of zero, then this message
    * can be inspected to find out which port was automatically assigned.
    */
   case class Bound(localAddress: InetSocketAddress) extends Event
 
   /**
-   * The “simple sender” sends this message type in response to a [[SimpleSender]] query.
+   * The “simple sender” sends this message type in response to a [[akka.io.Udp.SimpleSender]] query.
    */
   sealed trait SimpleSenderReady extends Event
   case object SimpleSenderReady extends SimpleSenderReady
 
   /**
-   * This message is sent by the listener actor in response to an [[Unbind]] command
+   * This message is sent by the listener actor in response to an [[akka.io.Udp.Unbind]] command
    * after the socket has been closed.
    */
   sealed trait Unbound
@@ -171,7 +171,7 @@ object Udp extends ExtensionKey[UdpExt] {
   /**
    * Scala API: This object provides access to all socket options applicable to UDP sockets.
    *
-   * For the Java API see [[UdpSO]].
+   * For the Java API see [[akka.io.Udp.UdpSO]].
    */
   object SO extends Inet.SoForwarders {
 
@@ -241,33 +241,33 @@ object UdpMessage {
   import language.implicitConversions
 
   /**
-   * Each [[Send]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[Send#ack]]
+   * Each [[akka.io.Udp.Send]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[akka.io.Udp.Send#ack]]
    * must be set to an instance of this class. The token contained within can be used
-   * to recognize which write failed when receiving a [[CommandFailed]] message.
+   * to recognize which write failed when receiving a [[akka.io.Udp.CommandFailed]] message.
    */
   def noAck(token: AnyRef): NoAck = NoAck(token)
   /**
-   * Default [[NoAck]] instance which is used when no acknowledgment information is
+   * Default [[akka.io.Udp.NoAck]] instance which is used when no acknowledgment information is
    * explicitly provided. Its “token” is `null`.
    */
   def noAck: NoAck = NoAck
 
   /**
    * This message is understood by the “simple sender” which can be obtained by
-   * sending the [[SimpleSender]] query to the [[UdpExt#manager]] as well as by
-   * the listener actors which are created in response to [[Bind]]. It will send
+   * sending the [[akka.io.Udp.SimpleSender]] query to the [[akka.io.Udp.UdpExt#manager]] as well as by
+   * the listener actors which are created in response to [[akka.io.Udp.Bind]]. It will send
    * the given payload data as one UDP datagram to the given target address. The
-   * UDP actor will respond with [[CommandFailed]] if the send could not be
+   * UDP actor will respond with [[akka.io.Udp.CommandFailed]] if the send could not be
    * enqueued to the O/S kernel because the send buffer was full. If the given
-   * `ack` is not of type [[NoAck]] the UDP actor will reply with the given
+   * `ack` is not of type [[akka.io.Udp.NoAck]] the UDP actor will reply with the given
    * object as soon as the datagram has been successfully enqueued to the O/S
    * kernel.
    *
    * The sending UDP socket’s address belongs to the “simple sender” which does
    * not handle inbound datagrams and sends from an ephemeral port; therefore
    * sending using this mechanism is not suitable if replies are expected, use
-   * [[Bind]] in that case.
+   * [[akka.io.Udp.Bind]] in that case.
    */
   def send(payload: ByteString, target: InetSocketAddress, ack: Event): Command = Send(payload, target, ack)
   /**
@@ -276,10 +276,10 @@ object UdpMessage {
   def send(payload: ByteString, target: InetSocketAddress): Command = Send(payload, target)
 
   /**
-   * Send this message to the [[UdpExt#manager]] in order to bind to the given
+   * Send this message to the [[akka.io.Udp.UdpExt#manager]] in order to bind to the given
    * local port (or an automatically assigned one if the port number is zero).
-   * The listener actor for the newly bound port will reply with a [[Bound]]
-   * message, or the manager will reply with a [[CommandFailed]] message.
+   * The listener actor for the newly bound port will reply with a [[akka.io.Udp.Bound]]
+   * message, or the manager will reply with a [[akka.io.Udp.CommandFailed]] message.
    */
   def bind(handler: ActorRef, endpoint: InetSocketAddress, options: JIterable[SocketOption]): Command =
     Bind(handler, endpoint, options.asScala.to)
@@ -289,15 +289,15 @@ object UdpMessage {
   def bind(handler: ActorRef, endpoint: InetSocketAddress): Command = Bind(handler, endpoint, Nil)
 
   /**
-   * Send this message to the listener actor that previously sent a [[Bound]]
+   * Send this message to the listener actor that previously sent a [[akka.io.Udp.Bound]]
    * message in order to close the listening socket. The recipient will reply
-   * with an [[Unbound]] message.
+   * with an [[akka.io.Udp.Unbound]] message.
    */
   def unbind: Command = Unbind
 
   /**
    * Retrieve a reference to a “simple sender” actor of the UDP extension.
-   * The newly created “simple sender” will reply with the [[SimpleSenderReady]] notification.
+   * The newly created “simple sender” will reply with the [[akka.io.Udp.SimpleSenderReady]] notification.
    *
    * The “simple sender” is a convenient service for being able to send datagrams
    * when the originating address is meaningless, i.e. when no reply is expected.
@@ -312,16 +312,16 @@ object UdpMessage {
   def simpleSender: Command = SimpleSender
 
   /**
-   * Send this message to a listener actor (which sent a [[Bound]] message) to
+   * Send this message to a listener actor (which sent a [[akka.io.Udp.Bound]] message) to
    * have it stop reading datagrams from the network. If the O/S kernel’s receive
    * buffer runs full then subsequent datagrams will be silently discarded.
-   * Re-enable reading from the socket using the [[ResumeReading]] command.
+   * Re-enable reading from the socket using the [[akka.io.Udp.ResumeReading]] command.
    */
   def suspendReading: Command = SuspendReading
 
   /**
    * This message must be sent to the listener actor to re-enable reading from
-   * the socket after a [[SuspendReading]] command.
+   * the socket after a [[akka.io.Udp.SuspendReading]] command.
    */
   def resumeReading: Command = ResumeReading
 }

--- a/spray-io/src/main/scala/akka/io/UdpConnected.scala
+++ b/spray-io/src/main/scala/akka/io/UdpConnected.scala
@@ -21,12 +21,10 @@ import akka.actor._
  *
  * This extension implements the connectionless UDP protocol with
  * calling `connect` on the underlying sockets, i.e. with restricting
- * from whom data can be received. For “unconnected” UDP mode see [[Udp]].
+ * from whom data can be received. For “unconnected” UDP mode see [[akka.io.Udp]].
  *
  * For a full description of the design and philosophy behind this IO
- * implementation please refer to {@see <a href="http://doc.akka.io/">the Akka online documentation</a>}.
- *
- * The Java API for generating UDP commands is available at [[UdpConnectedMessage]].
+ * implementation please refer to <a href="http://doc.akka.io/">the Akka online documentation</a>.
  */
 object UdpConnected extends ExtensionKey[UdpConnectedExt] {
   /**
@@ -35,7 +33,7 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
   override def get(system: ActorSystem): UdpConnectedExt = super.get(system)
 
   /**
-   * The common interface for [[Command]] and [[Event]].
+   * The common interface for [[akka.io.Udp.Command]] and [[akka.io.Udp.Event]].
    */
   sealed trait Message
 
@@ -47,15 +45,15 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
   }
 
   /**
-   * Each [[Send]] can optionally request a positive acknowledgment to be sent
-   * to the commanding actor. If such notification is not desired the [[Send#ack]]
+   * Each [[akka.io.Udp.Send]] can optionally request a positive acknowledgment to be sent
+   * to the commanding actor. If such notification is not desired the [[akka.io.Udp.Send#ack]]
    * must be set to an instance of this class. The token contained within can be used
-   * to recognize which write failed when receiving a [[CommandFailed]] message.
+   * to recognize which write failed when receiving a [[akka.io.Udp.CommandFailed]] message.
    */
   case class NoAck(token: Any) extends Event
 
   /**
-   * Default [[NoAck]] instance which is used when no acknowledgment information is
+   * Default [[akka.io.Udp.NoAck]] instance which is used when no acknowledgment information is
    * explicitly provided. Its “token” is `null`.
    */
   object NoAck extends NoAck(null)
@@ -63,8 +61,8 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
   /**
    * This message is understood by the connection actors to send data to their
    * designated destination. The connection actor will respond with
-   * [[CommandFailed]] if the send could not be enqueued to the O/S kernel
-   * because the send buffer was full. If the given `ack` is not of type [[NoAck]]
+   * [[akka.io.Udp.CommandFailed]] if the send could not be enqueued to the O/S kernel
+   * because the send buffer was full. If the given `ack` is not of type [[akka.io.Udp.NoAck]]
    * the connection actor will reply with the given object as soon as the datagram
    * has been successfully enqueued to the O/S kernel.
    */
@@ -79,7 +77,7 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
   }
 
   /**
-   * Send this message to the [[UdpExt#manager]] in order to bind to a local
+   * Send this message to the [[akka.io.UdpExt#manager]] in order to bind to a local
    * port (optionally with the chosen `localAddress`) and create a UDP socket
    * which is restricted to sending to and receiving from the given `remoteAddress`.
    * All received datagrams will be sent to the designated `handler` actor.
@@ -91,22 +89,22 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
 
   /**
    * Send this message to a connection actor (which had previously sent the
-   * [[Connected]] message) in order to close the socket. The connection actor
-   * will reply with a [[Disconnected]] message.
+   * [[akka.io.Udp.Connected]] message) in order to close the socket. The connection actor
+   * will reply with a [[akka.io.Udp.Disconnected]] message.
    */
   case object Disconnect extends Command
 
   /**
-   * Send this message to a listener actor (which sent a [[Bound]] message) to
+   * Send this message to a listener actor (which sent a [[akka.io.Udp.Bound]] message) to
    * have it stop reading datagrams from the network. If the O/S kernel’s receive
    * buffer runs full then subsequent datagrams will be silently discarded.
-   * Re-enable reading from the socket using the [[ResumeReading]] command.
+   * Re-enable reading from the socket using the [[akka.io.Udp.ResumeReading]] command.
    */
   case object SuspendReading extends Command
 
   /**
    * This message must be sent to the listener actor to re-enable reading from
-   * the socket after a [[SuspendReading]] command.
+   * the socket after a [[akka.io.Udp.SuspendReading]] command.
    */
   case object ResumeReading extends Command
 
@@ -117,7 +115,7 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
 
   /**
    * When a connection actor receives a datagram from its socket it will send
-   * it to the handler designated in the [[Bind]] message using this message type.
+   * it to the handler designated in the [[akka.io.Udp.Bind]] message using this message type.
    */
   case class Received(data: ByteString) extends Event
 
@@ -129,7 +127,7 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
 
   /**
    * This message is sent by the connection actor to the actor which sent the
-   * [[Connect]] message when the UDP socket has been bound to the local and
+   * [[akka.io.Udp.Connect]] message when the UDP socket has been bound to the local and
    * remote addresses given.
    */
   sealed trait Connected extends Event
@@ -137,7 +135,7 @@ object UdpConnected extends ExtensionKey[UdpConnectedExt] {
 
   /**
    * This message is sent by the connection actor to the actor which sent the
-   * [[Disconnect]] message when the UDP socket has been closed.
+   * [[akka.io.Udp.Disconnect]] message when the UDP socket has been closed.
    */
   sealed trait Disconnected extends Event
   case object Disconnected extends Disconnected


### PR DESCRIPTION
closes #472
