### PR TITLE
+ can: Add explicit suppression of Content-Type header

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
@@ -74,6 +74,22 @@ class RequestRendererSpec extends Specification {
         }
       }
 
+      "PUT request, a few headers and a body with suppressed content type" in new TestSetup() {
+        HttpRequest(PUT, "/abc/xyz", List(
+          RawHeader("X-Fancy", "naa"),
+          RawHeader("Cache-Control", "public"),
+          RawHeader("Host", "spray.io"))).withEntity(HttpEntity(ContentTypes.NoContentType, "The content please!")) must beRenderedTo {
+          """|PUT /abc/xyz HTTP/1.1
+             |X-Fancy: naa
+             |Cache-Control: public
+             |Host: spray.io
+             |User-Agent: spray-can/1.0.0
+             |Content-Length: 19
+             |
+             |The content please!"""
+        }
+      }
+
       "PUT request start (chunked) without body" in new TestSetup() {
         ChunkedRequestStart(HttpRequest(PUT, "/abc/xyz")) must beRenderedTo {
           """|PUT /abc/xyz HTTP/1.1

--- a/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
@@ -76,6 +76,24 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
         } -> false
       }
 
+      "a response with status 400, a few headers and a body with an explicitly supressed Content Type header" in new TestSetup() {
+        render {
+          HttpResponse(
+            status = 400,
+            headers = List(RawHeader("Age", "30"), Connection("Keep-Alive")),
+            entity = HttpEntity(contentType = ContentTypes.NoContentType, "Small f*ck up overhere!"))
+        } === result {
+          """HTTP/1.1 400 Bad Request
+            |Server: spray-can/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Age: 30
+            |Connection: Keep-Alive
+            |Content-Length: 23
+            |
+            |Small f*ck up overhere!"""
+        } -> false
+      }
+
       "a response to a HEAD request" in new TestSetup() {
         render(requestMethod = HEAD,
           response = HttpResponse(

--- a/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
@@ -54,8 +54,8 @@ trait RequestRenderingComponent {
       renderHeaders(headers)
       if (userAgent.isDefined) r ~~ userAgent.get ~~ CrLf
       entity match {
+        case HttpBody(ContentTypes.NoContentType, _) | EmptyEntity ⇒ // don't render Content-Type header
         case HttpBody(contentType, _) ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
-        case EmptyEntity              ⇒
       }
     }
 

--- a/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
@@ -73,8 +73,8 @@ trait ResponseRenderingComponent {
       if (status eq StatusCodes.OK) r ~~ DefaultStatusLine else r ~~ StatusLineStart ~~ status ~~ CrLf
       r ~~ serverAndDateHeader
       entity match {
+        case HttpBody(ContentTypes.NoContentType, _) | EmptyEntity ⇒ // don't render Content-Type header
         case HttpBody(contentType, _) ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
-        case EmptyEntity              ⇒
       }
       renderHeaders(headers)()
     }

--- a/spray-http/src/main/scala/spray/http/ContentType.scala
+++ b/spray-http/src/main/scala/spray/http/ContentType.scala
@@ -70,4 +70,7 @@ object ContentTypes {
   val `text/plain` = ContentType(MediaTypes.`text/plain`)
   val `text/plain(UTF-8)` = ContentType(MediaTypes.`text/plain`, HttpCharsets.`UTF-8`)
   val `application/octet-stream` = ContentType(MediaTypes.`application/octet-stream`)
+
+  // used for explicitly suppressing the rendering of Content-Type headers on requests and responses
+  val NoContentType = ContentType(MediaTypes.NoMediaType)
 }

--- a/spray-http/src/main/scala/spray/http/MediaType.scala
+++ b/spray-http/src/main/scala/spray/http/MediaType.scala
@@ -240,6 +240,10 @@ object MediaTypes extends ObjectRegistry[(String, String), MediaType] {
   private final val binary = true          // compile-time constant
   private final val notBinary = false      // compile-time constant
 
+  // dummy value currently only used by ContentType.NoContentType
+  private[http] val NoMediaType = new NonMultipartMediaType("none", "none", false, false, Seq.empty) {
+  }
+
   val `application/atom+xml`                                                      = app("atom+xml", compressible, notBinary, "atom")
   val `application/base64`                                                        = app("base64", compressible, binary, "mm", "mme")
   val `application/excel`                                                         = app("excel", uncompressible, binary, "xl", "xla", "xlb", "xlc", "xld", "xlk", "xll", "xlm", "xls", "xlt", "xlv", "xlw")


### PR DESCRIPTION
Closes #491

The NoContentType ContentType is ignored in response rendering.
The NoMediaType MediaType is encapsuled by NoContentType.
