### PR TITLE
= http: Fix Location header parsing to accept relative URIs

### DIFF
--- a/spray-http/src/main/scala/spray/http/parser/SimpleHeaders.scala
+++ b/spray-http/src/main/scala/spray/http/parser/SimpleHeaders.scala
@@ -61,7 +61,7 @@ private[parser] trait SimpleHeaders {
   }
 
   def `*Location` = rule {
-    oneOrMore(Text) ~> { uri ⇒ Location(Uri.parseAbsolute(uri)) } ~ EOI
+    oneOrMore(Text) ~> { uri ⇒ Location(Uri(uri)) } ~ EOI
   }
 
   def `*Proxy-Authenticate` = rule {

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -154,9 +154,10 @@ class HttpHeaderSpec extends Specification {
       "Last-Modified: Wed, 13 Jul 2011 08:12:31 GMT" ! example(`Last-Modified`(DateTime(2011, 7, 13, 8, 12, 31)))_ ^
       p ^
       "Location: https://spray.io/secure" ! example(Location(Uri("https://spray.io/secure")))_ ^
+      "Location: /en-us/default.aspx" ! example(Location(Uri("/en-us/default.aspx")))_ ^
       "Location: https://spray.io/{sec}" ! example(Location(Uri("https://spray.io/{sec}")), fix(_).replace("{", "%7B").replace("}", "%7D"))_ ^
-      "Location: https://spray.io/ sec" ! errorExample(ErrorInfo("Illegal HTTP header 'Location': Illegal absolute " +
-        "URI, unexpected character ' ' at position 17", "\nhttps://spray.io/ sec\n                 ^\n"))_ ^
+      "Location: https://spray.io/ sec" ! errorExample(ErrorInfo("Illegal HTTP header 'Location': Illegal URI " +
+        "reference, unexpected character ' ' at position 17", "\nhttps://spray.io/ sec\n                 ^\n"))_ ^
       p ^
       "Origin: http://spray.io" ! example(Origin(Uri("http://spray.io")))_ ^
       p ^


### PR DESCRIPTION
Fixes #484 to allow Location header parsing to accept relative URIs as per the [new spec](http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-22#section-7.1.2) linked by @jrudolph.
