### PR TITLE
= io: register for OP_CONNECT only after the connection attempt was made, fixes #437

### DIFF
--- a/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -34,7 +34,7 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
   localAddress.foreach(channel.socket.bind)
   options.foreach(_.beforeConnect(channel.socket))
-  channelRegistry.register(channel, SelectionKey.OP_CONNECT)
+  channelRegistry.register(channel, 0)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied
 
   private def stop(): Unit = stopWith(CloseInformation(Set(commander), connect.failureMessage))
@@ -55,8 +55,10 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
       reportConnectFailure {
         if (channel.connect(remoteAddress))
           completeConnect(registration, commander, options)
-        else
+        else {
+          registration.enableInterest(SelectionKey.OP_CONNECT)
           context.become(connecting(registration, commander, options, tcp.Settings.FinishConnectRetries))
+        }
       }
   }
 


### PR DESCRIPTION
This is necessary because of at least two bugs in the JDK:
- a channel is always connectable before the connection is attempted,
  and selecting for `OP_CONNECT` will instantly report connectable
- even worse: after `OP_CONNECT` was reported true, also `finishConnect`
  will always return true, even if the connection wasn't yet established

The corresponding issue in akka is https://www.assembla.com/spaces/akka/tickets/3602-io--tcp-connection-establishment-always-succeeds-even-if-endpoint-never-answers for which I will send a PR later
