### PR TITLE
= routing: migrate to shapeless 2.0.0-M1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val akkaSlf4j     = "com.typesafe.akka"                       %%  "akka-slf4j"                  % "2.1.4"
   val akkaTestKit   = "com.typesafe.akka"                       %%  "akka-testkit"                % "2.1.4"
   val parboiled     = "org.parboiled"                           %%  "parboiled-scala"             % "1.1.5"
-  val shapeless     = "com.chuusai"                             %%  "shapeless"                   % "1.2.4"
+  val shapeless     = "com.chuusai"                             %   "shapeless"                   % "2.0.0-M1" cross CrossVersion.full
   val scalatest     = "org.scalatest"                           %%  "scalatest"                   % "1.9.1"
   val specs2        = "org.specs2"                              %%  "specs2"                      % "1.14"
   val sprayJson     = "io.spray"                                %%  "spray-json"                  % "1.2.5"

--- a/spray-routing/src/main/scala/spray/routing/Prepender.scala
+++ b/spray-routing/src/main/scala/spray/routing/Prepender.scala
@@ -17,6 +17,7 @@
 package spray.routing
 
 import shapeless._
+import shapeless.ops.hlist.Prepend
 
 // TODO: check whether we can remove this additional layer on top of PrependAux
 trait Prepender[P <: HList, S <: HList] {
@@ -30,7 +31,7 @@ object Prepender {
     def apply(prefix: P, suffix: S) = prefix
   }
 
-  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: PrependAux[P, S, Out0]) =
+  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: Prepend.Aux[P, S, Out0]) =
     new Prepender[P, S] {
       type Out = Out0
       def apply(prefix: P, suffix: S): Out = prepend(prefix, suffix)

--- a/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
@@ -18,6 +18,7 @@ package spray.routing
 package directives
 
 import shapeless._
+import shapeless.ops.hlist._
 
 trait AnyParamDirectives {
   /**
@@ -73,10 +74,10 @@ trait AnyParamDefMagnet2[T] {
 }
 
 object AnyParamDefMagnet2 {
-  implicit def forTuple[T <: Product, L <: HList, Out](implicit hla: HListerAux[T, L],
+  implicit def forTuple[T <: Product, L <: HList, Out](implicit gen: Generic.Aux[T, L],
                                                        apdma: AnyParamDefMagnetAux[L]) =
     new AnyParamDefMagnet2[T] {
-      def apply(value: T) = apdma(hla(value))
+      def apply(value: T) = apdma(gen.to(value))
       type Out = apdma.Out
     }
 }
@@ -98,7 +99,7 @@ object AnyParamDefMagnetAux {
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]],
                                                                  pdma: ParamDefMagnetAux[T, Directive[LB]],
-                                                                 ev: PrependAux[LA, LB, Out]) = {
+                                                                 ev: Prepend.Aux[LA, LB, Out]) = {
 
       // see https://groups.google.com/forum/?fromgroups=#!topic/spray-user/HGEEdVajpUw
       def fdmaWrapper(t: T): Directive[LB] = fdma(t).hflatMap {


### PR DESCRIPTION
I'm not sure if we want to migrate to shapeless-2.0 right away but I wanted to see how difficult it would be. It was pretty easy and all the tests are passing.

I've also tried to come up with a new implementation for the `HListDeserializer` that doesn't require generating boilerplate. I've tried two approaches using shapeless's `Generic` and `FnToProduct` but I seem to hit a dead end on both. If you're interested I can create a gist to share it.
