### PR TITLE
+ routing: add Directive that allows a query param to override the request http method

### DIFF
--- a/docs/documentation/spray-routing/method-directives/methodOverrideParameter.rst
+++ b/docs/documentation/spray-routing/method-directives/methodOverrideParameter.rst
@@ -1,0 +1,13 @@
+.. _-overrideMethodWithParameter-:
+
+overrideMethodWithParameter
+===========================
+
+Changes the HTTP method of the request to the value of the specified query string parameter. If the query string
+parameter is not specified this directive has no effect. If the query string is specified as something that is not a
+HTTP method, then this directive completes the request with a 501 Not Implemented response.
+
+This directive is useful for:
+
+- Use in combination with JSONP (JSONP only supports GET)
+- Supporting older browsers that lack support for certain HTTP methods. E.g. IE8 does not support PATCH

--- a/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
+++ b/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
@@ -102,6 +102,8 @@ Directive                              Description
                                        function
 :ref:`-mapRouteResponsePF-`            Same as :ref:`-mapRouteResponse-`, but with a ``PartialFunction``
 :ref:`-method-`                        Rejects if the request method does not match a given one
+:ref:`-overrideMethodWithParameter-`   Changes the HTTP method of the request to the value of the specified query string
+                                       parameter
 :ref:`-noop-`                          Does nothing, i.e. passes the ``RequestContext`` unchanged to its inner Route
 :ref:`-onComplete-`                    "Unwraps" a ``Future[T]`` and runs its inner route after future completion with
                                        the future's value as an extraction of type ``Try[T]``

--- a/spray-routing-tests/src/test/scala/spray/routing/MethodDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/MethodDirectivesSpec.scala
@@ -16,7 +16,7 @@
 
 package spray.routing
 
-import spray.http.HttpMethods
+import spray.http.{ StatusCodes, HttpMethods }
 
 class MethodDirectivesSpec extends RoutingSpec {
 
@@ -42,6 +42,27 @@ class MethodDirectivesSpec extends RoutingSpec {
       } ~> check {
         rejections === List(MethodRejection(HttpMethods.GET))
       }
+    }
+  }
+
+  "overrideMethodWithParameter" should {
+    "change the request method" in {
+      Get("/?_method=put") ~> overrideMethodWithParameter("_method") {
+        get { complete("GET") } ~
+          put { complete("PUT") }
+      } ~> check { entityAs[String] === "PUT" }
+    }
+    "not affect the request when not specified" in {
+      Get() ~> overrideMethodWithParameter("_method") {
+        get { complete("GET") } ~
+          put { complete("PUT") }
+      } ~> check { entityAs[String] === "GET" }
+    }
+    "complete with 501 Not Implemented when not a valid method" in {
+      Get("/?_method=hallo") ~> overrideMethodWithParameter("_method") {
+        get { complete("GET") } ~
+          put { complete("PUT") }
+      } ~> check { status === StatusCodes.NotImplemented }
     }
   }
 


### PR DESCRIPTION
Added the `methodOverrideParameter` Directive which changes the HTTP method of the request to the value of the specified query string parameter. If the specified query string parameter is not set or is set as something that is not a HTTP method, this directive has no effect.

This directive is useful for:
- Use in combination with JSONP (JSONP only supports GET)
- Supporting older browsers that lack support for certain HTTP methods. E.g. IE8 does not support PATCH
