### PR TITLE
= docs: document the future directives

### DIFF
--- a/docs/documentation/spray-routing/code/docs/directives/FutureDirectivesExamplesSpec.scala
+++ b/docs/documentation/spray-routing/code/docs/directives/FutureDirectivesExamplesSpec.scala
@@ -5,6 +5,10 @@ import scala.concurrent.Future
 import scala.util.{Try, Success, Failure}
 import spray.util.LoggingContext
 import spray.routing.ExceptionHandler
+import akka.actor.{Actor, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import java.util.concurrent.TimeUnit
 
 class FutureDirectivesExamplesSpec extends DirectivesSpec {
   object TestException extends Throwable
@@ -18,6 +22,39 @@ class FutureDirectivesExamplesSpec extends DirectivesSpec {
   def handleResponse(response: Try[String]) = response match {
     case Success(value) => complete(value)
     case Failure(ex)    => failWith(ex)
+  }
+
+  val resourceActor = system.actorOf(Props(new Actor {
+    def receive = { case _ => sender ! "resource" }
+  }))
+  implicit val responseTimeout = Timeout(2, TimeUnit.SECONDS)
+
+  "single-execution" in {
+    val route =
+      onSuccess((resourceActor ? "GetResource").mapTo[String]) { resource =>
+        // inner routes will always use the resource computed at creation time.
+        complete(resource)
+      }
+
+    Get("/") ~> route ~> check {
+      status === OK
+      entityAs[String] === "resource"
+    }
+  }
+
+  "per-request-execution" in {
+    val route =
+      dynamic {
+        onSuccess((resourceActor ? "GetResource").mapTo[String]) { resources =>
+          // inner routes will get a fresh resource on every execution.
+          complete(resources)
+        }
+      }
+
+    Get("/") ~> route ~> check {
+      status === OK
+      entityAs[String] === "resource"
+    }
   }
 
   "example-1" in {

--- a/docs/documentation/spray-routing/future-directives/index.rst
+++ b/docs/documentation/spray-routing/future-directives/index.rst
@@ -11,3 +11,19 @@ Future directives can be used to run inner routes once the provided ``Future[T]`
    oncomplete
    onsuccess
    onfailure
+
+All future directives are evaluated once at route creation time and its result will always be used
+when evaluating the inner routes.
+
+Example
+-------
+
+.. includecode:: ../code/docs/directives/FutureDirectivesExamplesSpec.scala
+   :snippet: single-execution
+
+In case you need to evaluate the future with every request and the outer routes don't do any extractions (by
+extracting a value, a directive make its inner route dynamic) you can wrap your route with the :ref:`-dynamic-`
+directive as shown bellow.
+
+.. includecode:: ../code/docs/directives/FutureDirectivesExamplesSpec.scala
+   :snippet: per-request-execution

--- a/docs/documentation/spray-routing/future-directives/oncomplete.rst
+++ b/docs/documentation/spray-routing/future-directives/oncomplete.rst
@@ -15,11 +15,8 @@ Signature
 Description
 -----------
 
-The execution of the inner route passed to a onComplete directive is deferred until the given future
-has completed. The future is evaluated once at route creation time, ideally in order to prepare
-some costly resource necessary to evaluate the inner route. In case you need to evaluate the future
-per each request, consider wrapping the onComplete directive with the :ref:`-dynamic-`
-directive.
+The evaluation of the inner route passed to a onComplete directive is deferred until the given future
+has completed and provided with a extraction of type ``Try[T]``.
 
 It is necessary to bring a ``ExecutionContext`` into implicit scope for this directive to work.
 

--- a/docs/documentation/spray-routing/future-directives/onfailure.rst
+++ b/docs/documentation/spray-routing/future-directives/onfailure.rst
@@ -18,9 +18,7 @@ Description
 The execution of the inner route passed to a onFailure directive is deferred until the given future
 has completed with a failure, exposing the reason of failure as a extraction of type ``Throwable``.
 If the future succeeds the request is completed using the values marshaller (this directive therefore
-requires a marshaller for the future's type to be implicitly available). The future is evaluated
-once at route creation time, in case you need to evaluate the future per each request consider wrapping the
-onFailure directive with the :ref:`-dynamic-` directive.
+requires a marshaller for the future's type to be implicitly available).
 
 It is necessary to bring a ``ExecutionContext`` into implicit scope for this directive to work.
 

--- a/docs/documentation/spray-routing/future-directives/onsuccess.rst
+++ b/docs/documentation/spray-routing/future-directives/onsuccess.rst
@@ -17,10 +17,7 @@ Description
 
 The execution of the inner route passed to a onSuccess directive is deferred until the given future
 has completed successfully, exposing the future's value as a extraction of type ``T``. If the future
-fails its failure throwable is bubbled up to the nearest ``ExceptionHandler``. The future is evaluated
-once at route creation time, ideally in order to prepare some costly resource necessary to evaluate
-the inner route. In case you need to evaluate the future per each request, consider wrapping the
-onSuccess directive with the :ref:`-dynamic-` directive.
+fails its failure throwable is bubbled up to the nearest ``ExceptionHandler``.
 
 It is necessary to bring a ``ExecutionContext`` into implicit scope for this directive to work.
 


### PR DESCRIPTION
Included basic documentation using the info available in the source code.
