### PR TITLE
+ http: add CONNECT method and support for custom HTTP methods

### DIFF
--- a/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
@@ -63,7 +63,7 @@ trait RequestRenderingComponent {
     def renderRequest(request: HttpRequest): Unit = {
       renderRequestStart(request)
       val bodyLength = request.entity.data.length
-      if (bodyLength > 0 || request.method.entityAccepted) r ~~ `Content-Length` ~~ bodyLength ~~ CrLf
+      if (bodyLength > 0 || request.method.isEntityAccepted) r ~~ `Content-Length` ~~ bodyLength ~~ CrLf
       r ~~ CrLf ~~ request.entity.data
     }
 

--- a/spray-http/src/main/scala/spray/http/HttpEncoding.scala
+++ b/spray-http/src/main/scala/spray/http/HttpEncoding.scala
@@ -25,7 +25,7 @@ case class HttpEncoding private[http] (value: String) extends HttpEncodingRange 
 }
 
 object HttpEncoding {
-  def custom(value: String) = apply(value)
+  def custom(value: String): HttpEncoding = apply(value)
 }
 
 // see http://www.iana.org/assignments/http-parameters/http-parameters.xml

--- a/spray-http/src/main/scala/spray/http/HttpMethod.scala
+++ b/spray-http/src/main/scala/spray/http/HttpMethod.scala
@@ -19,12 +19,12 @@ package spray.http
 /**
  * @param isSafe true if the resource should not be altered on the server
  * @param isIdempotent true if requests can be safely (& automatically) repeated
- * @param entityAccepted true if meaning of request entities is properly defined
+ * @param isEntityAccepted true if meaning of request entities is properly defined
  */
 case class HttpMethod private[http] (value: String,
                                      isSafe: Boolean,
                                      isIdempotent: Boolean,
-                                     entityAccepted: Boolean) extends LazyValueBytesRenderable {
+                                     isEntityAccepted: Boolean) extends LazyValueBytesRenderable {
   // for faster equality checks we use the hashcode of the method name (and make sure it's distinct during registration)
   private[http] val fingerprint = value.##
 
@@ -38,20 +38,29 @@ case class HttpMethod private[http] (value: String,
     }
 }
 
+object HttpMethod {
+  def custom(value: String, safe: Boolean, idempotent: Boolean, entityAccepted: Boolean): HttpMethod = {
+    require(value.nonEmpty, "value must be non-empty")
+    require(!safe || idempotent, "An HTTP method cannot be safe without being idempotent")
+    apply(value, safe, idempotent, entityAccepted)
+  }
+}
+
 object HttpMethods extends ObjectRegistry[String, HttpMethod] {
-  private def register(method: HttpMethod): HttpMethod = {
+  def register(method: HttpMethod): HttpMethod = {
     registry.values foreach { m ⇒ if (m.fingerprint == method.fingerprint) sys.error("Method fingerprint collision") }
     register(method.value, method)
   }
 
   // format: OFF
-  val DELETE  = register(HttpMethod("DELETE" , isSafe = false, isIdempotent = true , entityAccepted = false))
-  val GET     = register(HttpMethod("GET"    , isSafe = true , isIdempotent = true , entityAccepted = false))
-  val HEAD    = register(HttpMethod("HEAD"   , isSafe = true , isIdempotent = true , entityAccepted = false))
-  val OPTIONS = register(HttpMethod("OPTIONS", isSafe = true , isIdempotent = true , entityAccepted = true))
-  val PATCH   = register(HttpMethod("PATCH"  , isSafe = false, isIdempotent = false, entityAccepted = true))
-  val POST    = register(HttpMethod("POST"   , isSafe = false, isIdempotent = false, entityAccepted = true))
-  val PUT     = register(HttpMethod("PUT"    , isSafe = false, isIdempotent = true , entityAccepted = true))
-  val TRACE   = register(HttpMethod("TRACE"  , isSafe = true , isIdempotent = true , entityAccepted = false))
+  val CONNECT = register(HttpMethod("CONNECT", isSafe = false, isIdempotent = false, isEntityAccepted = false))
+  val DELETE  = register(HttpMethod("DELETE" , isSafe = false, isIdempotent = true , isEntityAccepted = false))
+  val GET     = register(HttpMethod("GET"    , isSafe = true , isIdempotent = true , isEntityAccepted = false))
+  val HEAD    = register(HttpMethod("HEAD"   , isSafe = true , isIdempotent = true , isEntityAccepted = false))
+  val OPTIONS = register(HttpMethod("OPTIONS", isSafe = true , isIdempotent = true , isEntityAccepted = true))
+  val PATCH   = register(HttpMethod("PATCH"  , isSafe = false, isIdempotent = false, isEntityAccepted = true))
+  val POST    = register(HttpMethod("POST"   , isSafe = false, isIdempotent = false, isEntityAccepted = true))
+  val PUT     = register(HttpMethod("PUT"    , isSafe = false, isIdempotent = true , isEntityAccepted = true))
+  val TRACE   = register(HttpMethod("TRACE"  , isSafe = true , isIdempotent = true , isEntityAccepted = false))
   // format: ON
 }


### PR DESCRIPTION
closes #428

We don't want to add even even more (and comparatively rarely used) predefined methods in order to avoid namespace pollution (an `import HttpMethods._` is probably quite frequent).
