### PR TITLE
= can & http: allow custom Content-Type and Content-Length headers when ...

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
@@ -19,12 +19,13 @@ package rendering
 
 import java.net.InetSocketAddress
 import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
 import akka.event.NoLogging
 import spray.util.EOL
 import spray.http._
 import HttpHeaders._
 import HttpMethods._
-import org.specs2.specification.Scope
+import MediaTypes._
 
 class RequestRendererSpec extends Specification {
 
@@ -45,7 +46,7 @@ class RequestRendererSpec extends Specification {
         HttpRequest(POST, "/abc/xyz", List(
           RawHeader("X-Fancy", "naa"),
           RawHeader("Age", "0"),
-          RawHeader("Host", "spray.io:9999"))) must beRenderedTo {
+          Host("spray.io", 9999))) must beRenderedTo {
           """|POST /abc/xyz HTTP/1.1
              |X-Fancy: naa
              |Age: 0
@@ -61,7 +62,7 @@ class RequestRendererSpec extends Specification {
         HttpRequest(PUT, "/abc/xyz", List(
           RawHeader("X-Fancy", "naa"),
           RawHeader("Cache-Control", "public"),
-          RawHeader("Host", "spray.io"))).withEntity("The content please!") must beRenderedTo {
+          Host("spray.io"))).withEntity("The content please!") must beRenderedTo {
           """|PUT /abc/xyz HTTP/1.1
              |X-Fancy: naa
              |Cache-Control: public
@@ -78,7 +79,7 @@ class RequestRendererSpec extends Specification {
         HttpRequest(PUT, "/abc/xyz", List(
           RawHeader("X-Fancy", "naa"),
           RawHeader("Cache-Control", "public"),
-          RawHeader("Host", "spray.io"))).withEntity(HttpEntity(ContentTypes.NoContentType, "The content please!")) must beRenderedTo {
+          Host("spray.io"))).withEntity(HttpEntity(ContentTypes.NoContentType, "The content please!")) must beRenderedTo {
           """|PUT /abc/xyz HTTP/1.1
              |X-Fancy: naa
              |Cache-Control: public
@@ -90,14 +91,15 @@ class RequestRendererSpec extends Specification {
         }
       }
 
-      "PUT request start (chunked) without body" in new TestSetup() {
-        ChunkedRequestStart(HttpRequest(PUT, "/abc/xyz")) must beRenderedTo {
-          """|PUT /abc/xyz HTTP/1.1
-             |Host: test.com:8080
-             |User-Agent: spray-can/1.0.0
-             |Transfer-Encoding: chunked
-             |
-             |"""
+      "PUT request start (chunked) without body but custom Content-Type" in new TestSetup() {
+        ChunkedRequestStart(HttpRequest(PUT, "/abc/xyz", List(`Content-Type`(`text/plain`)))) must beRenderedTo {
+          """PUT /abc/xyz HTTP/1.1
+            |Content-Type: text/plain
+            |Host: test.com:8080
+            |User-Agent: spray-can/1.0.0
+            |Transfer-Encoding: chunked
+            |
+            |"""
         }
       }
 
@@ -130,7 +132,7 @@ class RequestRendererSpec extends Specification {
       }
 
       "GET request with overridden User-Agent and without body" in new TestSetup(None) {
-        HttpRequest(GET, "/abc", List(RawHeader("User-Agent", "blah-blah/1.0"))) must beRenderedTo {
+        HttpRequest(GET, "/abc", List(`User-Agent`("blah-blah/1.0"))) must beRenderedTo {
           """GET /abc HTTP/1.1
             |User-Agent: blah-blah/1.0
             |Host: test.com:8080
@@ -140,7 +142,7 @@ class RequestRendererSpec extends Specification {
       }
 
       "GET request with overridden User-Agent and without body" in new TestSetup(Some(`User-Agent`("settings-ua/1.0"))) {
-        HttpRequest(GET, "/abc", List(RawHeader("User-Agent", "user-ua/1.0"))) must beRenderedTo {
+        HttpRequest(GET, "/abc", List(`User-Agent`("user-ua/1.0"))) must beRenderedTo {
           """GET /abc HTTP/1.1
             |User-Agent: user-ua/1.0
             |Host: test.com:8080

--- a/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RequestRenderingComponent.scala
@@ -29,46 +29,83 @@ private[can] trait RequestRenderingComponent {
 
   def renderRequestPart(r: Rendering, part: HttpRequestPart, serverAddress: InetSocketAddress,
                         log: LoggingAdapter): Unit = {
-    def renderRequestStart(request: HttpRequest): Unit = {
-      import request._
-      @tailrec def renderHeaders(remaining: List[HttpHeader], hostHeaderSeen: Boolean = false, userAgentSeen: Boolean = false): Unit =
+    def renderRequestStart(request: HttpRequest, allowUserContentType: Boolean,
+                           userSpecifiedContentLength: Boolean): Unit = {
+      def render(h: HttpHeader) = r ~~ h ~~ CrLf
+      def suppressionWarning(h: HttpHeader, msg: String = "the spray-can HTTP layer sets this header automatically!"): Unit =
+        log.warning("Explicitly set request header '{}' is ignored, {}", h, msg)
+
+      @tailrec def renderHeaders(remaining: List[HttpHeader], hostHeaderSeen: Boolean = false,
+                                 userAgentSeen: Boolean = false, contentTypeSeen: Boolean = false,
+                                 contentLengthSeen: Boolean = false): Unit =
         remaining match {
+          case head :: tail ⇒ head match {
+            case x: `Content-Type` ⇒
+              val seen =
+                if (contentTypeSeen) { suppressionWarning(x, "another `Content-Type` header was already rendered"); true }
+                else if (!allowUserContentType) { suppressionWarning(x, "the request Content-Type is set via the request's HttpEntity!"); false }
+                else { render(x); true }
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen, contentTypeSeen = seen, contentLengthSeen)
+
+            case x: `Content-Length` ⇒
+              val seen =
+                if (contentLengthSeen) { suppressionWarning(x, "another `Content-Length` header was already rendered"); true }
+                else if (!userSpecifiedContentLength) { suppressionWarning(x); false }
+                else { render(x); true }
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen, contentTypeSeen, contentLengthSeen = seen)
+
+            case `Transfer-Encoding`(_) ⇒
+              suppressionWarning(head)
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen, contentTypeSeen, contentLengthSeen)
+
+            case x: `Host` ⇒
+              render(x)
+              renderHeaders(tail, hostHeaderSeen = true, userAgentSeen, contentTypeSeen, contentLengthSeen)
+
+            case x: `User-Agent` ⇒
+              render(x)
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen = true, contentTypeSeen, contentLengthSeen)
+
+            case x: RawHeader if x.lowercaseName == "content-type" ||
+              x.lowercaseName == "content-length" ||
+              x.lowercaseName == "transfer-encoding" ||
+              x.lowercaseName == "host" ||
+              x.lowercaseName == "user-agent" ⇒
+              suppressionWarning(x, "illegal RawHeader")
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen, contentTypeSeen, contentLengthSeen)
+
+            case x ⇒
+              render(x)
+              renderHeaders(tail, hostHeaderSeen, userAgentSeen, contentTypeSeen, contentLengthSeen)
+          }
+
           case Nil ⇒
             if (!hostHeaderSeen) r ~~ Host(serverAddress) ~~ CrLf
             if (!userAgentSeen && userAgent.isDefined) r ~~ userAgent.get ~~ CrLf
-          case head :: tail ⇒
-            def logHeaderSuppressionWarning(msg: String): Unit =
-              log.warning("Explicitly set request header '{}' is ignored, {}", head, msg)
-
-            head.lowercaseName match {
-              case "content-type" if entity.nonEmpty ⇒
-                logHeaderSuppressionWarning("the request Content-Type is set via the request's HttpEntity!")
-                renderHeaders(tail, hostHeaderSeen, userAgentSeen)
-              case "content-length" | "transfer-encoding" ⇒
-                logHeaderSuppressionWarning("the spray-can HTTP layer sets this header automatically!")
-                renderHeaders(tail, hostHeaderSeen, userAgentSeen)
-              case "user-agent" ⇒ r ~~ head ~~ CrLf; renderHeaders(tail, hostHeaderSeen, userAgentSeen = true)
-              case "host"       ⇒ r ~~ head ~~ CrLf; renderHeaders(tail, hostHeaderSeen = true, userAgentSeen)
-              case _            ⇒ r ~~ head ~~ CrLf; renderHeaders(tail, hostHeaderSeen, userAgentSeen)
+            if (!contentLengthSeen && userSpecifiedContentLength)
+              log.error("Chunkless streamed request is missing user-specified Content-Length header")
+            request.entity match {
+              case HttpEntity.NonEmpty(ContentTypes.NoContentType, _) ⇒
+              case HttpEntity.NonEmpty(contentType, _) if !contentTypeSeen ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
+              case _ ⇒
             }
         }
+
+      import request._
       uri.renderWithoutFragment(r ~~ request.method ~~ ' ', UTF8) ~~ ' ' ~~ protocol ~~ CrLf
       renderHeaders(headers)
-      entity match {
-        case HttpEntity.NonEmpty(ContentTypes.NoContentType, _) | HttpEntity.Empty ⇒ // don't render Content-Type header
-        case HttpEntity.NonEmpty(contentType, _)                                   ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
-      }
     }
 
     def renderRequest(request: HttpRequest): Unit = {
-      renderRequestStart(request)
+      renderRequestStart(request, allowUserContentType = false, userSpecifiedContentLength = false)
       val bodyLength = request.entity.data.length
       if (bodyLength > 0 || request.method.isEntityAccepted) r ~~ `Content-Length` ~~ bodyLength ~~ CrLf
       r ~~ CrLf ~~ request.entity.data
     }
 
     def renderChunkedRequestStart(request: HttpRequest): Unit = {
-      renderRequestStart(request)
+      renderRequestStart(request, allowUserContentType = request.entity.isEmpty,
+        userSpecifiedContentLength = false) // change to `userSpecifiedContentLength = chunkless` when implementing chunkless request streaming
       r ~~ `Transfer-Encoding` ~~ Chunked ~~ CrLf ~~ CrLf
       request.entity match {
         case x: HttpEntity.NonEmpty ⇒ r ~~ MessageChunk(x.data)

--- a/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
@@ -28,7 +28,6 @@ import RenderSupport._
 private[can] trait ResponseRenderingComponent {
   def serverHeaderValue: String
   def chunklessStreaming: Boolean
-  def transparentHeadRequests: Boolean
 
   private[this] val serverHeaderPlusDateColonSP =
     serverHeaderValue match {
@@ -36,52 +35,83 @@ private[can] trait ResponseRenderingComponent {
       case x  ⇒ ("Server: " + x + "\r\nDate: ").getAsciiBytes
     }
 
+  // returns a boolean indicating whether the connection is to be closed after this response was sent
   def renderResponsePartRenderingContext(r: Rendering, ctx: ResponsePartRenderingContext,
                                          log: LoggingAdapter): Boolean = {
-    def renderResponseStart(response: HttpResponse): Connection = {
-      val manualContentHeadersAllowed =
-        transparentHeadRequests && ctx.requestMethod == HttpMethods.HEAD && response.entity.isEmpty
+    def renderResponseStart(response: HttpResponse, allowUserContentType: Boolean,
+                            allowUserContentLength: Boolean): Connection = {
+      def render(h: HttpHeader) = r ~~ h ~~ CrLf
+      def suppressionWarning(h: HttpHeader, msg: String = "the spray-can HTTP layer sets this header automatically!"): Unit =
+        log.warning("Explicitly set response header '{}' is ignored, {}", h, msg)
 
-      @tailrec def renderHeaders(remaining: List[HttpHeader])(connectionHeader: Connection = null): Connection =
+      @tailrec def renderHeaders(remaining: List[HttpHeader], userContentType: Boolean = false,
+                                 userContentLength: Boolean = false, connHeader: Connection = null): Connection =
         remaining match {
-          case Nil ⇒ connectionHeader
-          case head :: tail ⇒ renderHeaders(tail) {
-            def logHeaderSuppressionWarning(msg: String = "the spray-can HTTP layer sets this header automatically!"): Connection = {
-              log.warning("Explicitly set response header '{}' is ignored, {}", head, msg)
-              connectionHeader
-            }
-            head match {
-              case _: `Content-Type` if !manualContentHeadersAllowed ⇒ logHeaderSuppressionWarning("the response Content-Type is set via the response's HttpEntity!")
-              case _: `Content-Length` if !manualContentHeadersAllowed ⇒ logHeaderSuppressionWarning()
-              case _: `Transfer-Encoding` ⇒ logHeaderSuppressionWarning()
-              case _: `Date` ⇒ logHeaderSuppressionWarning()
-              case _: `Server` ⇒ logHeaderSuppressionWarning()
-              case x: `Connection` ⇒
-                r ~~ x ~~ CrLf
-                if (connectionHeader eq null) x else Connection(x.tokens ++ connectionHeader.tokens)
-              case x: RawHeader if x.lowercaseName == "content-type" ||
-                x.lowercaseName == "content-length" ||
-                x.lowercaseName == "transfer-encoding" ||
-                x.lowercaseName == "date" ||
-                x.lowercaseName == "server" ||
-                x.lowercaseName == "connection" ⇒ logHeaderSuppressionWarning()
-              case _ ⇒ r ~~ head ~~ CrLf; connectionHeader
-            }
+          case head :: tail ⇒ head match {
+            case x: `Content-Type` ⇒
+              val userCT =
+                if (userContentType) { suppressionWarning(x, "another `Content-Type` header was already rendered"); true }
+                else if (!allowUserContentType) { suppressionWarning(x, "the response Content-Type is set via the response's HttpEntity!"); false }
+                else { render(x); true }
+              renderHeaders(tail, userContentType = userCT, userContentLength, connHeader)
+
+            case x: `Content-Length` ⇒
+              val userCL =
+                if (userContentLength) { suppressionWarning(x, "another `Content-Length` header was already rendered"); true }
+                else if (!allowUserContentLength) { suppressionWarning(x); false }
+                else { render(x); true }
+              renderHeaders(tail, userContentType, userContentLength = userCL, connHeader)
+
+            case `Transfer-Encoding`(_) | Date(_) | Server(_) ⇒
+              suppressionWarning(head)
+              renderHeaders(tail, userContentType, userContentLength, connHeader)
+
+            case x: `Connection` ⇒
+              val connectionHeader = if (connHeader eq null) x else Connection(x.tokens ++ connHeader.tokens)
+              renderHeaders(tail, userContentType, userContentLength, connectionHeader)
+
+            case x: RawHeader if x.lowercaseName == "content-type" ||
+              x.lowercaseName == "content-length" ||
+              x.lowercaseName == "transfer-encoding" ||
+              x.lowercaseName == "date" ||
+              x.lowercaseName == "server" ||
+              x.lowercaseName == "connection" ⇒
+              suppressionWarning(x, "illegal RawHeader")
+              renderHeaders(tail, userContentType, userContentLength, connHeader)
+
+            case x ⇒
+              render(x)
+              renderHeaders(tail, userContentType, userContentLength, connHeader)
           }
+
+          case Nil ⇒
+            response.entity match {
+              case HttpEntity.NonEmpty(ContentTypes.NoContentType, _) ⇒
+              case HttpEntity.NonEmpty(contentType, _) if !userContentType ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
+              case _ ⇒
+            }
+            val result =
+              if (userContentLength) {
+                // if we have a user-specified Content-Length we are in chunkless response streaming mode and the client
+                // will assume that we keep the connection open after the response is finished
+                // however, we currently do not support keeping the response open after a chunkless streaming response
+                if (response.protocol == `HTTP/1.1`) Connection("close")
+                else null // in the `HTTP/1.0` response case we simply don't render any Connection header
+              } else connHeader
+            if (result != null) render(result)
+            result
         }
       import response._
       if (status eq StatusCodes.OK) r ~~ DefaultStatusLine else r ~~ StatusLineStart ~~ status ~~ CrLf
       r ~~ serverAndDateHeader
-      entity match {
-        case HttpEntity.NonEmpty(ContentTypes.NoContentType, _) | HttpEntity.Empty ⇒ // don't render Content-Type header
-        case HttpEntity.NonEmpty(contentType, _)                                   ⇒ r ~~ `Content-Type` ~~ contentType ~~ CrLf
-      }
-      renderHeaders(headers)()
+      renderHeaders(headers)
     }
 
     def renderResponse(response: HttpResponse): Boolean = {
       import response._
-      val connectionHeader = renderResponseStart(response)
+      val connectionHeader = renderResponseStart(response,
+        allowUserContentType = entity.isEmpty && ctx.requestMethod == HttpMethods.HEAD,
+        allowUserContentLength = false)
       val close =
         ctx.requestProtocol match {
           case `HTTP/1.0` ⇒ if (connectionHeader eq null) {
@@ -95,14 +125,17 @@ private[can] trait ResponseRenderingComponent {
         }
 
       // don't set a Content-Length header for non-keep-alive HTTP/1.0 responses (rely on body end by connection close)
-      if (response.protocol == `HTTP/1.1` || !close) r ~~ `Content-Length` ~~ entity.data.length ~~ CrLf
+      if (response.protocol == `HTTP/1.1` || !close || ctx.requestMethod == HttpMethods.HEAD)
+        r ~~ `Content-Length` ~~ entity.data.length ~~ CrLf
       r ~~ CrLf
       if (entity.nonEmpty && ctx.requestMethod != HttpMethods.HEAD) r ~~ entity.data
       close
     }
 
     def renderChunkedResponseStart(response: HttpResponse, chunkless: Boolean): Boolean = {
-      renderResponseStart(response)
+      renderResponseStart(response,
+        allowUserContentType = response.entity.isEmpty,
+        allowUserContentLength = chunkless)
       if (!chunkless) r ~~ `Transfer-Encoding` ~~ Chunked ~~ CrLf
       r ~~ CrLf
       if (ctx.requestMethod != HttpMethods.HEAD)

--- a/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
+++ b/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
@@ -27,7 +27,6 @@ private object ResponseRendering {
     new PipelineStage with ResponseRenderingComponent {
       def serverHeaderValue: String = settings.serverHeader
       def chunklessStreaming: Boolean = settings.chunklessStreaming
-      def transparentHeadRequests: Boolean = settings.transparentHeadRequests
 
       def apply(context: PipelineContext, commandPL: CPL, eventPL: EPL): Pipelines =
         new Pipelines {


### PR DESCRIPTION
...required, closes #543

Also prepares the spray-can RequestRenderingComponent for chunkless request streaming.
