### PR TITLE
! can: Implement redirection following (issue #132)

### DIFF
--- a/docs/documentation/spray-can/http-client/index.rst
+++ b/docs/documentation/spray-can/http-client/index.rst
@@ -137,3 +137,41 @@ is to simply bring one into scope implicitly:
 .. includecode:: ../code/docs/HttpServerExamplesSpec.scala
    :snippet: sslcontext-provision
 
+
+Redirection Following
+---------------------
+
+Automatic redirection following for 3xx responses is supported by setting the ``spray.can.host-connector.max-redirects``
+as follows:
+
+ - If set to zero redirection responses will not be followed, i.e. they'll be returned to the user as is.
+ - If set to a value > zero redirection responses will be followed up to the given number of times.
+ - If the redirection chain is longer than the configured value the first redirection response that is
+   is not followed anymore is returned to the user as is.
+
+By default ``max-redirects`` is set to 0.
+
+Since this setting is at the host level, it is possible to configure a different number of ``max-redirects`` for
+different hosts (see :ref:`RequestLevelApi`). In this situation the ``max-redirects`` configured for the host of the
+initial request is respected for the entire redirection chain. This is true even if redirection means changing to another
+host.
+
+Which redirects are followed?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This table shows which http method is used to follow redirects for given request methods and response status codes. Any
+Request method and response status code combination not in the table will not result in redirection following and the
+response will be returned as is.
+
+.. rst-class:: table table-striped
+
+======================== ======================= ========================== ==============
+Request Method           Response Status Code    Redirection Method         Specification
+======================== ======================= ========================== ==============
+GET / HEAD               301 / 302 / 303 / 307   Original request method    `RFC 2616`_
+Any (except GET / HEAD)  302 / 303               GET                        `RFC 2616`_
+Any                      308                     Original request method    `Draft Spec`_
+======================== ======================= ========================== ==============
+
+.. _RFC 2616: http://tools.ietf.org/html/rfc2616#section-10.3
+.. _Draft Spec: http://tools.ietf.org/html/draft-reschke-http-status-308-07#section-3

--- a/spray-can/src/main/resources/reference.conf
+++ b/spray-can/src/main/resources/reference.conf
@@ -240,6 +240,13 @@ spray.can {
     # giving up and returning an error.
     max-retries = 5
 
+    # Configures redirection following.
+    # If set to zero redirection responses will not be followed, i.e. they'll be returned to the user as is.
+    # If set to a value > zero redirection responses will be followed up to the given number of times.
+    # If the redirection chain is longer than the configured value the first redirection response that is
+    # is not followed anymore is returned to the user as is.
+    max-redirects = 0
+
     # If this setting is enabled, the `HttpHostConnector` pipelines requests
     # across connections, otherwise only one single request can be "open"
     # on a particular HTTP connection.

--- a/spray-can/src/main/scala/spray/can/HttpManager.scala
+++ b/spray-can/src/main/scala/spray/can/HttpManager.scala
@@ -24,6 +24,7 @@ import spray.can.client._
 import spray.can.server.HttpListener
 import spray.http._
 import Http.{ ClientConnectionType, HostConnectorSetup }
+import HttpHostConnector.RequestContext
 
 private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor with ActorLogging {
   import HttpManager._
@@ -42,18 +43,21 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
     case request: HttpRequest ⇒
       try {
         val req = request.withEffectiveUri(securedConnection = false)
-        val host = req.uri.authority.host
-        val connector = connectorFor(HostConnectorSetup(host.toString, req.uri.effectivePort, sslEncryption = req.uri.scheme == "https"))
+        val connector = connectorForUri(req.uri)
         // never render absolute URIs here and we also drop any potentially existing fragment
-        val relativeUri = Uri(
-          path = if (req.uri.path.isEmpty) Uri.Path./ else req.uri.path,
-          query = req.uri.query)
-        connector.forward(req.copy(uri = relativeUri))
+        connector.forward(req.copy(uri = req.uri.toRelative.withoutFragment))
       } catch {
         case NonFatal(e) ⇒
           log.error("Illegal request: {}", e.getMessage)
           sender ! Status.Failure(e)
       }
+
+    // 3xx Redirect
+    case ctx @ RequestContext(req, _, _, commander) ⇒
+      val connector = connectorForUri(req.uri)
+      // never render absolute URIs here and we also drop any potentially existing fragment
+      val newReq = req.copy(uri = req.uri.toRelative.withoutFragment)
+      connector.tell(ctx.copy(request = newReq), commander)
 
     case (request: HttpRequest, setup: HostConnectorSetup) ⇒
       connectorFor(setup).forward(request)
@@ -75,10 +79,10 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
 
     case cmd: Http.CloseAll ⇒ shutdownSettingsGroups(cmd, Set(sender))
   }
-  
-  def newHttpListener(commander: ActorRef, bind: Http.Bind, httpSettings: HttpExt#Settings) = 
+
+  def newHttpListener(commander: ActorRef, bind: Http.Bind, httpSettings: HttpExt#Settings) =
     new HttpListener(commander, bind, httpSettings)
-    
+
   def withTerminationManagement(behavior: Receive): Receive = ({
     case ev @ Terminated(child) ⇒
       if (listeners contains child)
@@ -159,6 +163,11 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
       case Terminated(child) if running contains child ⇒ self.tell(Http.Unbound, child)
     }
 
+  def connectorForUri(uri: Uri) = {
+    val host = uri.authority.host
+    connectorFor(HostConnectorSetup(host.toString, uri.effectivePort, sslEncryption = uri.scheme == "https"))
+  }
+
   def connectorFor(setup: HostConnectorSetup) = {
     val normalizedSetup = resolveAutoProxied(setup)
     import ClientConnectionType._
@@ -205,7 +214,7 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
     }
     settingsGroups.getOrElse(settings, createAndRegisterSettingsGroup)
   }
-  def newHttpClientSettingsGroup(settings: ClientConnectionSettings, httpSettings: HttpExt#Settings) = 
+  def newHttpClientSettingsGroup(settings: ClientConnectionSettings, httpSettings: HttpExt#Settings) =
     new HttpClientSettingsGroup(settings, httpSettings)
 }
 

--- a/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
+++ b/spray-can/src/main/scala/spray/can/client/HostConnectorSettings.scala
@@ -23,12 +23,14 @@ import spray.util._
 case class HostConnectorSettings(
     maxConnections: Int,
     maxRetries: Int,
+    maxRedirects: Int,
     pipelining: Boolean,
     idleTimeout: Duration,
     connectionSettings: ClientConnectionSettings) {
 
   require(maxConnections > 0, "max-connections must be > 0")
   require(maxRetries >= 0, "max-retries must be >= 0")
+  require(maxRedirects >= 0, "max-redirects must be >= 0")
   requirePositive(idleTimeout)
 }
 
@@ -36,6 +38,7 @@ object HostConnectorSettings extends SettingsCompanion[HostConnectorSettings]("s
   def fromSubConfig(c: Config) = apply(
     c getInt "host-connector.max-connections",
     c getInt "host-connector.max-retries",
+    c getInt "host-connector.max-redirects",
     c getBoolean "host-connector.pipelining",
     c getDuration "host-connector.idle-timeout",
     ClientConnectionSettings fromSubConfig c.getConfig("client"))

--- a/spray-client/src/test/scala/spray/client/RedirectionIntegrationSpec.scala
+++ b/spray-client/src/test/scala/spray/client/RedirectionIntegrationSpec.scala
@@ -1,0 +1,115 @@
+package spray.client
+
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+import com.typesafe.config.ConfigFactory
+import akka.actor.{ Actor, Props, ActorSystem }
+import spray.can.Http
+import spray.http._
+import spray.http.HttpHeaders.Location
+import akka.io.IO
+import spray.http.StatusCodes._
+import akka.pattern.ask
+import spray.util._
+import scala.concurrent.duration._
+import akka.util.Timeout
+
+/**
+ * Date: 05/10/2013
+ * Time: 22:17
+ */
+class RedirectionIntegrationSpec extends Specification with NoTimeConversions {
+  val testConf = ConfigFactory.parseString("""
+    akka {
+      event-handlers = ["akka.testkit.TestEventListener"]
+      loglevel = WARNING
+    }
+    spray.can {
+      host-connector {
+        max-redirects = 5
+      }
+    }""")
+  implicit val system = ActorSystem(Utils.actorSystemNameFrom(getClass), testConf)
+  import system.dispatcher
+  val (interfaceA, portA) = Utils.temporaryServerHostnameAndPort()
+  val (interfaceB, portB) = Utils.temporaryServerHostnameAndPort()
+
+  implicit val timeout = Timeout(10.seconds)
+
+  val connectA = Http.Connect(interfaceA, portA)
+  val transport = IO(Http)(spray.util.actorSystem)
+
+  step {
+    val serviceA = system.actorOf {
+      Props {
+        new Actor {
+          def receive = {
+            case x: Http.Connected ⇒ sender ! Http.Register(self)
+            case x: HttpRequest if x.uri.path.toString == "/redirect-rel" ⇒ sender ! redirectRel("/foo")
+            case x: HttpRequest if x.uri.path.toString == "/redirect-abs" ⇒ sender ! redirectAbs(interfaceB, portB, "/foo")
+            case x: HttpRequest if x.uri.path.toString == "/base/redirect-rel-dot" ⇒ sender ! redirectRel("./foo/../bar")
+            case x: HttpRequest if x.uri.path.toString == "/redirect-inf" ⇒ sender ! redirectRel("/redirect-inf")
+            case x: HttpRequest ⇒ sender ! HttpResponse(entity = "service-a" + x.uri.path.toString)
+            case _: Http.ConnectionClosed ⇒ // ignore
+          }
+        }
+      }
+    }
+    IO(Http).ask(Http.Bind(serviceA, interfaceA, portA))(3.seconds).await
+
+    val serviceB = system.actorOf {
+      Props {
+        new Actor {
+          def receive = {
+            case x: Http.Connected        ⇒ sender ! Http.Register(self)
+            case x: HttpRequest           ⇒ sender ! HttpResponse(entity = "service-b" + x.uri.path.toString)
+            case _: Http.ConnectionClosed ⇒ // ignore
+          }
+        }
+      }
+    }
+    IO(Http).ask(Http.Bind(serviceB, interfaceB, portB))(3.seconds).await
+  }
+
+  def redirectRel(path: String) =
+    HttpResponse(status = PermanentRedirect, headers = Location(Uri(s"$path")) :: Nil)
+
+  def redirectAbs(interface: String, port: Int, path: String) =
+    HttpResponse(status = PermanentRedirect, headers = Location(Uri(s"http://$interface:$port$path")) :: Nil)
+
+  "An HttpDialog" should {
+    "follow relative redirect responses" in {
+      HttpDialog(transport)
+        .send(HttpRequest(uri = s"http://$interfaceA:$portA/redirect-rel"))
+        .end
+        .map(_.entity.asString)
+        .await === "service-a/foo"
+    }
+    "follow absolute redirect responses to other hosts" in {
+      HttpDialog(transport)
+        .send(HttpRequest(uri = s"http://$interfaceA:$portA/redirect-abs"))
+        .end
+        .map(_.entity.asString)
+        .await === "service-b/foo"
+    }
+    "follow relative redirect responses with dot (./ and  ../) notation" in {
+      HttpDialog(transport)
+        .send(HttpRequest(uri = s"http://$interfaceA:$portA/base/redirect-rel-dot"))
+        .end
+        .map(_.entity.asString)
+        .await === "service-a/base/bar"
+    }
+    "NOT redirect infinitely" in {
+      val uri = s"http://$interfaceA:$portA/redirect-inf"
+      HttpDialog(transport)
+        .send(HttpRequest(uri = uri))
+        .end
+        .map(_.status)
+        .await === PermanentRedirect
+    }
+  }
+
+  step {
+    system.shutdown()
+  }
+}

--- a/spray-http/src/main/scala/spray/http/Uri.scala
+++ b/spray-http/src/main/scala/spray/http/Uri.scala
@@ -172,6 +172,18 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
                                 defaultAuthority: Authority = Authority.Empty): Uri =
     effectiveHttpRequestUri(scheme, authority.host, authority.port, path, query, fragment, securedConnection,
       hostHeaderHost, hostHeaderPort, defaultAuthority)
+
+  /**
+   * Converts this URI into a relative URI by keeping the path, query and fragment, but dropping the scheme and authority.
+   */
+  def toRelative =
+    Uri(path = if (path.isEmpty) Uri.Path./ else path, query = query, fragment = fragment)
+
+  /**
+   * Drops the fragment from this URI
+   */
+  def withoutFragment =
+    copy(fragment = None)
 }
 
 object Uri {

--- a/spray-testkit/src/main/scala/spray/testkit/RouteTest.scala
+++ b/spray-testkit/src/main/scala/spray/testkit/RouteTest.scala
@@ -78,11 +78,11 @@ trait RouteTest extends RequestBuilding with RouteResultComponent {
     if (r.size == 1) r.head else failTest("Expected a single rejection but got %s (%s)".format(r.size, r))
   }
 
-    /**
-     * A dummy that can be used as `~> runRoute` to run the route but without blocking for the result.
-     * The result of the pipeline is the result that can later be checked with `check`. See the
-     * "separate running route from checking" example from ScalatestRouteTestSpec.scala.
-     */
+  /**
+   * A dummy that can be used as `~> runRoute` to run the route but without blocking for the result.
+   * The result of the pipeline is the result that can later be checked with `check`. See the
+   * "separate running route from checking" example from ScalatestRouteTestSpec.scala.
+   */
   def runRoute: RouteResult ⇒ RouteResult = identity
 
   // there is already an implicit class WithTransformation in scope (inherited from spray.httpx.TransformerPipelineSupport)


### PR DESCRIPTION
Implemented redirection following for `3xx` responses in the spray-can layer.

Both relative and absolute URLs in the `Location` header are supported. Despite the HTTP spec [only stating](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.30) that absolute URLs need be supported, it seems that most clients do support relative URLs also.

Added details to the [docs](http://spray.io/documentation/1.2.2/spray-can/http-client/#redirection-following)
