### PR TITLE
+ servlet: add `spray.servlet.uri-parsing-mode` setting, fixes #574

### DIFF
--- a/spray-servlet/src/main/resources/reference.conf
+++ b/spray-servlet/src/main/resources/reference.conf
@@ -64,4 +64,18 @@ spray.servlet {
     # If a header cannot be parsed into a high-level model instance it will be
     # provided as a `RawHeader`.
     illegal-header-warnings = on
+
+    # Sets the strictness mode for parsing request target URIs.
+    # The following values are defined:
+    #
+    # `strict`: RFC3986-compliant URIs are required,
+    #     a 400 response is triggered on violations
+    #
+    # `relaxed`: all visible 7-Bit ASCII chars are allowed
+    #
+    # `relaxed-with-raw-query`: like `relaxed` but additionally
+    #     the URI query is not parsed, but delivered as one raw string
+    #     as the `key` value of a single Query structure element.
+    #
+    uri-parsing-mode = relaxed
 }

--- a/spray-servlet/src/main/scala/spray/servlet/ConnectorSettings.scala
+++ b/spray-servlet/src/main/scala/spray/servlet/ConnectorSettings.scala
@@ -31,7 +31,8 @@ case class ConnectorSettings(
     verboseErrorMessages: Boolean,
     maxContentLength: Long,
     servletRequestAccess: Boolean,
-    illegalHeaderWarnings: Boolean) {
+    illegalHeaderWarnings: Boolean,
+    uriParsingMode: Uri.ParsingMode) {
 
   require(!bootClass.isEmpty,
     "No boot class configured. Please specify a boot class FQN in the spray.servlet.boot-class config setting.")
@@ -53,5 +54,6 @@ object ConnectorSettings extends SettingsCompanion[ConnectorSettings]("spray.ser
     c getBoolean "verbose-error-messages",
     c getBytes "max-content-length",
     c getBoolean "servlet-request-access",
-    c getBoolean "illegal-header-warnings")
+    c getBoolean "illegal-header-warnings",
+    Uri.ParsingMode(c getString "uri-parsing-mode"))
 }

--- a/spray-servlet/src/main/scala/spray/servlet/ModelConverter.scala
+++ b/spray-servlet/src/main/scala/spray/servlet/ModelConverter.scala
@@ -61,7 +61,7 @@ object ModelConverter {
   def rebuildUri(hsRequest: HttpServletRequest)(implicit settings: ConnectorSettings, log: LoggingAdapter): Uri = {
     val buffer = addQueryString(hsRequest, hsRequest.getRequestURL())
     try {
-      val uri = Uri(buffer.toString)
+      val uri = Uri(buffer.toString, settings.uriParsingMode)
       if (settings.rootPath.isEmpty) uri
       else if (uri.path.startsWith(settings.rootPath)) uri.copy(path = uri.path.dropChars(settings.rootPathCharCount))
       else {

--- a/spray-servlet/src/test/scala/spray/servlet/ModelConverterSpec.scala
+++ b/spray-servlet/src/test/scala/spray/servlet/ModelConverterSpec.scala
@@ -41,7 +41,8 @@ class ModelConverterSpec extends Specification with NoTimeConversions {
     verboseErrorMessages = true,
     maxContentLength = 16,
     servletRequestAccess = false,
-    illegalHeaderWarnings = false)
+    illegalHeaderWarnings = false,
+    uriParsingMode = Uri.ParsingMode.Relaxed)
 
   val remoteAddress = `Remote-Address`("127.0.0.7")
   val textPlain = `Content-Type`(ContentTypes.`text/plain`)
@@ -85,6 +86,13 @@ class ModelConverterSpec extends Specification with NoTimeConversions {
         implicit def s = settings
         ModelConverter.toHttpRequest(RequestMock(headers = "Cookie" -> "foo=bar; bar=baz" :: Nil)) ===
           HttpRequest(headers = Cookie(HttpCookie("foo", "bar"), HttpCookie("bar", "baz")) :: Nil)
+      }
+      "example 8" in {
+        implicit def s = settings.copy(uriParsingMode = Uri.ParsingMode.RelaxedWithRawQuery)
+        val queryMock = new RequestMock("https://foo.bar/abc/def") {
+          override def getQueryString: String = "a=1&b=2&b=3=4&c"
+        }
+        ModelConverter.toHttpRequest(queryMock).uri.query === Uri.Query.Raw("a=1&b=2&b=3=4&c")
       }
     }
 


### PR DESCRIPTION
In contrast to `spray.can.server.uri-parsing-mode` the default is set to 'relaxed' to keep compatibility.
