### PR TITLE
= can: change default `pipelining-limit` to 1, enable auto-backpressure ...

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
@@ -37,12 +37,13 @@ class SprayCanClientSpec extends Specification {
     akka.loglevel = ERROR
     akka.io.tcp.trace-logging = off
     spray.can.client.request-timeout = 500ms
-    spray.can.server.verbose-error-messages = on
+    spray.can.client.response-chunk-aggregation-limit = 0
     spray.can.host-connector.max-retries = 1
     spray.can.host-connector.idle-timeout = infinite
     spray.can.host-connector.client.request-timeout = 500ms
+    spray.can.server.pipelining-limit = 4
+    spray.can.server.verbose-error-messages = on
     spray.can.server.request-chunk-aggregation-limit = 0
-    spray.can.client.response-chunk-aggregation-limit = 0
     spray.can.server.transparent-head-requests = off""")
   implicit val system = ActorSystem(actorSystemNameFrom(getClass), testConf)
 

--- a/spray-can-tests/src/test/scala/spray/can/server/SprayCanServerSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/server/SprayCanServerSpec.scala
@@ -42,8 +42,9 @@ class SprayCanServerSpec extends Specification with NoTimeConversions {
       io.tcp.trace-logging = off
     }
     spray.can.server.request-chunk-aggregation-limit = 0
-    spray.can.client.response-chunk-aggregation-limit = 0
-    spray.can.server.verbose-error-messages = on""")
+    spray.can.server.pipelining-limit = 4
+    spray.can.server.verbose-error-messages = on
+    spray.can.client.response-chunk-aggregation-limit = 0""")
   implicit val system = ActorSystem(getClass.getSimpleName, testConf)
 
   "The server-side spray-can HTTP infrastructure" should {

--- a/spray-can/src/main/resources/reference.conf
+++ b/spray-can/src/main/resources/reference.conf
@@ -30,7 +30,7 @@ spray.can {
     # Set to 'disabled' for completely disabling pipelining limits
     # (not recommended on public-facing servers due to risk of DoS attacks).
     # This value must be > 0 and <= 128.
-    pipelining-limit = 8
+    pipelining-limit = 1
 
     # The time after which an idle connection will be automatically closed.
     # Set to `infinite` to completely disable idle connection timeouts.

--- a/spray-can/src/main/scala/spray/can/server/HttpServerConnection.scala
+++ b/spray-can/src/main/scala/spray/can/server/HttpServerConnection.scala
@@ -216,6 +216,6 @@ private object HttpServerConnection {
       ConnectionTimeouts(idleTimeout) ? (reapingCycle.isFinite && idleTimeout.isFinite) >>
       SslTlsSupport(maxEncryptionChunkSize, parserSettings.sslSessionInfoHeader) ? sslEncryption >>
       TickGenerator(reapingCycle) ? (reapingCycle.isFinite && (idleTimeout.isFinite || requestTimeout.isFinite)) >>
-      BackPressureHandling(backpressureSettings.get.noAckRate, backpressureSettings.get.readingLowWatermark) ? backpressureSettings.isDefined
+      BackPressureHandling(backpressureSettings.get.noAckRate, backpressureSettings.get.readingLowWatermark) ? autoBackPressureEnabled
   }
 }

--- a/spray-can/src/main/scala/spray/can/server/OpenRequest.scala
+++ b/spray-can/src/main/scala/spray/can/server/OpenRequest.scala
@@ -207,7 +207,7 @@ private trait OpenRequestComponent { component ⇒
       val responsePart = part.messagePart.asInstanceOf[HttpResponsePart]
       val ack = part.ack match {
         case None ⇒
-          if (settings.backpressureSettings.isDefined) Tcp.NoAck else Tcp.NoAck(PartAndSender(responsePart, context.sender))
+          if (settings.autoBackPressureEnabled) Tcp.NoAck else Tcp.NoAck(PartAndSender(responsePart, context.sender))
         case Some(x) ⇒
           pendingSentAcks += 1
           AckEventWithReceiver(x, handler)

--- a/spray-can/src/main/scala/spray/can/server/ServerSettings.scala
+++ b/spray-can/src/main/scala/spray/can/server/ServerSettings.scala
@@ -51,6 +51,8 @@ case class ServerSettings(
   require(0 <= requestChunkAggregationLimit, "request-chunk-aggregation-limit must be >= 0")
   require(0 <= responseHeaderSizeHint, "response-size-hint must be > 0")
   require(0 < maxEncryptionChunkSize, "max-encryption-chunk-size must be > 0")
+
+  def autoBackPressureEnabled: Boolean = backpressureSettings.isDefined && (pipeliningLimit > 1)
 }
 
 object ServerSettings extends SettingsCompanion[ServerSettings]("spray.can.server") {


### PR DESCRIPTION
...only if limit > 1, closes #591
