### PR TITLE
! routing: remove superfluous `RequestContext::complete` overloads

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicToResponseMarshallers.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicToResponseMarshallers.scala
@@ -9,7 +9,9 @@ trait BasicToResponseMarshallers {
 
   // No implicit conversion to StatusCode allowed here: in `complete(i: Int)`, `i` shouldn't be marshalled
   // as a StatusCode
-  implicit def fromStatusCode: ToResponseMarshaller[StatusCode] = fromResponse.compose(s ⇒ HttpResponse(status = s))
+  implicit def fromStatusCode: ToResponseMarshaller[StatusCode] =
+    fromResponse.compose(s ⇒ HttpResponse(status = s, entity = s.defaultMessage))
+
   implicit def fromStatusCodeAndT[S, T](implicit sConv: S ⇒ StatusCode, tMarshaller: Marshaller[T]): ToResponseMarshaller[(S, T)] =
     fromStatusCodeAndHeadersAndT[T].compose { case (s, t) ⇒ (sConv(s), Nil, t) }
 

--- a/spray-routing/src/main/scala/spray/routing/RequestContext.scala
+++ b/spray-routing/src/main/scala/spray/routing/RequestContext.scala
@@ -216,12 +216,6 @@ case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPa
     }
 
   /**
-   * Completes the request with the given status code and its default message as the response entity.
-   */
-  def complete(status: StatusCode): Unit =
-    complete(HttpResponse(status, entity = status.defaultMessage))
-
-  /**
    * Completes the request with status "200 Ok" and the response entity created by marshalling the given object using
    * the in-scope marshaller for the type.
    */
@@ -229,7 +223,7 @@ case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPa
     val ctx = new ToResponseMarshallingContext {
       def tryAccept(contentTypes: Seq[ContentType]) = request.acceptableContentType(contentTypes)
       def rejectMarshalling(onlyTo: Seq[ContentType]): Unit = reject(UnacceptedResponseContentTypeRejection(onlyTo))
-      def marshalTo(response: HttpResponse): Unit = complete(response)
+      def marshalTo(response: HttpResponse): Unit = responder ! response
       def handleError(error: Throwable): Unit = failWith(error)
       def startChunkedMessage(response: HttpResponse, sentAck: Option[Any])(implicit sender: ActorRef) = {
         val chunkStart = ChunkedResponseStart(response)
@@ -240,49 +234,6 @@ case class RequestContext(request: HttpRequest, responder: ActorRef, unmatchedPa
     }
     marshaller(obj, ctx)
   }
-
-  /**
-   * Completes the request with the given status and the response entity created by marshalling the given object using
-   * the in-scope marshaller for the type.
-   */
-  def complete[T: Marshaller](status: StatusCode, obj: T): Unit =
-    complete(status, Nil, obj)
-
-  /**
-   * Completes the request with the given status, headers and the response entity created by marshalling the
-   * given object using the in-scope marshaller for the type.
-   */
-  def complete[T](status: StatusCode, headers: List[HttpHeader], obj: T)(implicit marshaller: Marshaller[T]): Unit = {
-    val ctx = new MarshallingContext {
-      def tryAccept(contentTypes: Seq[ContentType]) = request.acceptableContentType(contentTypes)
-      def rejectMarshalling(onlyTo: Seq[ContentType]): Unit = reject(UnacceptedResponseContentTypeRejection(onlyTo))
-      def marshalTo(entity: HttpEntity, headers: HttpHeader*): Unit = complete(response(entity, headers))
-      def handleError(error: Throwable): Unit = failWith(error)
-      def startChunkedMessage(entity: HttpEntity, sentAck: Option[Any], headers: Seq[HttpHeader])(implicit sender: ActorRef) = {
-        val chunkStart = ChunkedResponseStart(response(entity, headers))
-        val wrapper = if (sentAck.isEmpty) chunkStart else Confirmed(chunkStart, sentAck.get)
-        responder.tell(wrapper, sender)
-        responder
-      }
-      def response(entity: HttpEntity, h: Seq[HttpHeader]) = HttpResponse(status, entity, headers ++ h)
-    }
-    marshaller(obj, ctx)
-  }
-
-  /**
-   * Completes the request with the given [[spray.http.HttpResponse]].
-   */
-  def complete(response: HttpResponse): Unit =
-    responder ! response
-
-  /**
-   * Schedules the completion of the request with result of the given future.
-   */
-  def complete(future: Future[HttpResponse])(implicit ec: ExecutionContext): Unit =
-    future.onComplete {
-      case Success(response) ⇒ complete(response)
-      case Failure(error)    ⇒ failWith(error)
-    }
 
   /**
    * Bubbles the given error up the response chain where it is dealt with by the closest `handleExceptions`


### PR DESCRIPTION
Even though formally a breaking change most code shouldn't be affected by it since the implicit constructors for `ToResponseMarshaller` should cover all the removed methods.
