### PR TITLE
= can: change to `ConfirmedClose` for regular closing of server-side HTTP connections

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/server/ResponseRenderingSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/server/ResponseRenderingSpec.scala
@@ -70,7 +70,7 @@ class ResponseRenderingSpec extends Specification with Specs2PipelineStageTest {
           |
           |"""
       }
-      commands.expectMsg(Http.Close)
+      commands.expectMsg(Http.ConfirmedClose)
     }
   }
 }

--- a/spray-can-tests/src/test/scala/spray/can/server/SprayCanServerSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/server/SprayCanServerSpec.scala
@@ -143,11 +143,11 @@ class SprayCanServerSpec extends Specification with NoTimeConversions {
           val socket = openClientSocket()
           val serverHandler = acceptConnection()
           val writer = write(socket, request + "\r\n\r\n")
-          serverHandler.expectMsg(Http.Closed)
           val (text, reader) = readAll(socket)()
+          socket.close()
+          serverHandler.expectMsg(Http.ConfirmedClosed)
           text must startWith("HTTP/1.1 400 Bad Request")
           text.takeRight(errorMsg.length) === errorMsg
-          socket.close()
         }
       "when an HTTP/1.1 request has no Host header" in errorTest(
         request = "GET / HTTP/1.1",

--- a/spray-can/src/main/scala/spray/can/server/RequestChunkAggregation.scala
+++ b/spray-can/src/main/scala/spray/can/server/RequestChunkAggregation.scala
@@ -58,7 +58,8 @@ private object RequestChunkAggregation {
           def closeWithError(): Unit = {
             val msg = "Aggregated request entity greater than configured limit of " + limit + " bytes"
             context.log.error(msg + ", closing connection")
-            commandPL(ResponsePartRenderingContext(HttpResponse(StatusCodes.RequestEntityTooLarge, msg)))
+            commandPL(ResponsePartRenderingContext(HttpResponse(StatusCodes.RequestEntityTooLarge, msg),
+              closeAfterResponseCompletion = true))
             commandPL(Http.Close)
             eventPipeline.become(eventPL) // disable this stage
           }

--- a/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
+++ b/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
@@ -35,7 +35,7 @@ private object ResponseRendering {
               val rendering = new HttpDataRendering(settings.responseHeaderSizeHint)
               val close = renderResponsePartRenderingContext(rendering, ctx, context.log)
               commandPL(toTcpWriteCommand(rendering.get, ctx.ack))
-              if (close) commandPL(Http.Close)
+              if (close) commandPL(Http.ConfirmedClose)
 
             case cmd ⇒ commandPL(cmd)
           }


### PR DESCRIPTION
closes #614
