### PR TITLE
= httpx: Make play dependency optional in OSGi Import-Package statement

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -108,7 +108,8 @@ object Build extends Build {
       "spray.json.*;resolution := optional",
       "net.liftweb.*;resolution := optional",
       "org.json4s.*;resolution := optional",
-      "twirl.*;resolution := optional"
+      "twirl.*;resolution := optional",
+      "play.*;resolution := optional"
     )): _*)
     .settings(libraryDependencies ++=
       compile(mimepull) ++


### PR DESCRIPTION
6e29993af7dc1661dc6cc75884600b3ae31699e1 added an optional dependency on play to spray-httpx but the Import-Package statement is mandatory. This PR changes the Import-Package constraint to optional.
