### PR TITLE
= http: don't leak exceptions from `HttpCharset.custom`, fixes #637

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpCharset.scala
+++ b/spray-http/src/main/scala/spray/http/HttpCharset.scala
@@ -41,7 +41,9 @@ object HttpCharset {
   def custom(value: String, aliases: String*): Option[HttpCharset] =
     try Some(HttpCharset(value)(aliases: _*))
     catch {
-      case e: java.nio.charset.UnsupportedCharsetException ⇒ None
+      // per documentation all exceptions thrown by `Charset.forName`
+      // are IllegalArgumentExceptions
+      case e: IllegalArgumentException ⇒ None
     }
 }
 


### PR DESCRIPTION
Still, this won't fix the original problem that a missing charset will fail the request. Is there anything we can do about this?
