### PR TITLE
= project: ensure that all line endings are unix style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure that all line endings are the same. Required for the unit tests.
+* text=auto eol=lf

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -28,7 +28,7 @@ import HttpEncodings._
 import HttpMethods._
 
 class HttpHeaderSpec extends Specification {
-  val EOL = System.getProperty("line.separator")
+  val EOL = "\n"
   val `application/vnd.spray` = MediaTypes.register(MediaType.custom("application/vnd.spray"))
 
   "The HTTP header model must correctly parse and render the following headers" >> {

--- a/spray-util/src/main/scala/spray/util/package.scala
+++ b/spray-util/src/main/scala/spray/util/package.scala
@@ -32,7 +32,7 @@ import util.pimps._
 
 package object util {
 
-  val EOL = System.getProperty("line.separator")
+  val EOL = "\n"
   val UTF8 = Charset.forName("UTF8")
   val US_ASCII = Charset.forName("US-ASCII")
   val EmptyByteArray = Array.empty[Byte]


### PR DESCRIPTION
Fixes #632. By ensuring that all line-endings are Unix style, unit tests don't have to take into account the line-ending style of the platform. The line-ending style of the platform may be different than the style of Git, which causes unit-tests to fail.

For users that have set a different line-ending than Unix style in Git have to checkout the project again to get the their files in the right style.
