### PR TITLE
+ httpx: add some more marshalling helpers

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/MarshallingContext.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/MarshallingContext.scala
@@ -19,7 +19,7 @@ package spray.httpx.marshalling
 import akka.actor.ActorRef
 import spray.http._
 
-trait MarshallingContext { self ⇒
+trait MarshallingContext {
 
   /**
    * Determines whether the given ContentType is acceptable.
@@ -61,30 +61,39 @@ trait MarshallingContext { self ⇒
    * Creates a new MarshallingContext based on this one, that overrides the ContentType of the produced entity
    * with the given one.
    */
-  def withContentTypeOverriding(contentType: ContentType): MarshallingContext =
-    new DelegatingMarshallingContext(self) {
+  def withContentTypeOverriding(contentType: ContentType): MarshallingContext = {
+    val overridingCtx = withEntityMapped {
+      case HttpEntity.Empty ⇒ HttpEntity.Empty
+      case HttpEntity.NonEmpty(ct, data) ⇒
+        val c =
+          if (contentType.noCharsetDefined && ct.isCharsetDefined) contentType.withCharset(ct.charset)
+          else contentType
+        HttpEntity(c, data)
+    }
+    new DelegatingMarshallingContext(overridingCtx) {
       override def tryAccept(cts: Seq[ContentType]) =
         Some(if (contentType.isCharsetDefined) cts.head.withCharset(contentType.charset) else cts.head)
+    }
+  }
+
+  /**
+   * Creates a new MarshallingContext based on this one, that transforms the produced entity using
+   * the given function.
+   */
+  def withEntityMapped(f: HttpEntity ⇒ HttpEntity): MarshallingContext =
+    new DelegatingMarshallingContext(this) {
       override def marshalTo(entity: HttpEntity, headers: HttpHeader*): Unit =
-        self.marshalTo(overrideContentType(entity), headers: _*)
+        underlying.marshalTo(f(entity), headers: _*)
       override def startChunkedMessage(entity: HttpEntity, ack: Option[Any], headers: Seq[HttpHeader])(implicit sender: ActorRef) =
-        self.startChunkedMessage(overrideContentType(entity), ack, headers)
-      private def overrideContentType(entity: HttpEntity) =
-        entity.flatMap {
-          case HttpEntity.NonEmpty(ct, data) ⇒
-            val c =
-              if (contentType.noCharsetDefined && ct.isCharsetDefined) contentType.withCharset(ct.charset)
-              else contentType
-            HttpEntity(c, data)
-        }
+        underlying.startChunkedMessage(f(entity), ack, headers)
     }
 }
 
 /**
- * A convenience helper base class simplifying the construction of MarshallingContext that
- * wrap another MarshallingContext with some extra logic.
+ * A convenience helper base class simplifying the construction of a MarshallingContext that
+ * wraps another MarshallingContext with some extra logic.
  */
-class DelegatingMarshallingContext(underlying: MarshallingContext) extends MarshallingContext {
+class DelegatingMarshallingContext(protected val underlying: MarshallingContext) extends MarshallingContext {
   def tryAccept(contentTypes: Seq[ContentType]) = underlying.tryAccept(contentTypes)
   def rejectMarshalling(supported: Seq[ContentType]): Unit = underlying.rejectMarshalling(supported)
   def marshalTo(entity: HttpEntity, headers: HttpHeader*): Unit = underlying.marshalTo(entity, headers: _*)
@@ -93,7 +102,7 @@ class DelegatingMarshallingContext(underlying: MarshallingContext) extends Marsh
     underlying.startChunkedMessage(entity, ack, headers)
 }
 
-trait ToResponseMarshallingContext { self ⇒
+trait ToResponseMarshallingContext {
   /**
    * Determines whether the given ContentType is acceptable.
    * If the given ContentType does not define a charset an accepted charset is selected, i.e. the method guarantees
@@ -132,24 +141,46 @@ trait ToResponseMarshallingContext { self ⇒
    * Creates a new ToResponseMarshallingContext based on this one, that overrides the ContentType of the produced entity
    * with the given one.
    */
-  def withContentTypeOverriding(contentType: ContentType): ToResponseMarshallingContext =
-    new ToResponseMarshallingContext {
-      def tryAccept(cts: Seq[ContentType]): Option[ContentType] =
-        Some(if (contentType.isCharsetDefined) cts.head.withCharset(contentType.charset) else cts.head)
-      def rejectMarshalling(supported: Seq[ContentType]): Unit = self.rejectMarshalling(supported)
-      def marshalTo(response: HttpResponse): Unit = self.marshalTo(overrideContentType(response))
-      def handleError(error: Throwable): Unit = self.handleError(error)
-      def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
-        self.startChunkedMessage(overrideContentType(response), ack)
-      private def overrideContentType(response: HttpResponse) =
-        response.withEntity {
-          response.entity.flatMap {
-            case HttpEntity.NonEmpty(ct, data) ⇒
-              val c =
-                if (contentType.noCharsetDefined && ct.isCharsetDefined) contentType.withCharset(ct.charset)
-                else contentType
-              HttpEntity(c, data)
-          }
+  def withContentTypeOverriding(contentType: ContentType): ToResponseMarshallingContext = {
+    val overridingCtx = withResponseMapped { response ⇒
+      response.withEntity {
+        response.entity.flatMap {
+          case HttpEntity.NonEmpty(ct, data) ⇒
+            val c =
+              if (contentType.noCharsetDefined && ct.isCharsetDefined) contentType.withCharset(ct.charset)
+              else contentType
+            HttpEntity(c, data)
         }
+      }
     }
+    new DelegatingToResponseMarshallingContext(overridingCtx) {
+      override def tryAccept(cts: Seq[ContentType]) =
+        Some(if (contentType.isCharsetDefined) cts.head.withCharset(contentType.charset) else cts.head)
+    }
+  }
+
+  /**
+   * Creates a new ToResponseMarshallingContext based on this one, that transforms the produced response using
+   * the given function.
+   */
+  def withResponseMapped(f: HttpResponse ⇒ HttpResponse): ToResponseMarshallingContext =
+    new DelegatingToResponseMarshallingContext(this) {
+      override def marshalTo(response: HttpResponse): Unit = underlying.marshalTo(f(response))
+      override def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
+        underlying.startChunkedMessage(f(response), ack)
+    }
+}
+
+/**
+ * A convenience helper base class simplifying the construction of a ToResponseMarshallingContext that
+ * wraps another ToResponseMarshallingContext with some extra logic.
+ */
+class DelegatingToResponseMarshallingContext(protected val underlying: ToResponseMarshallingContext)
+    extends ToResponseMarshallingContext {
+  def tryAccept(contentTypes: Seq[ContentType]) = underlying.tryAccept(contentTypes)
+  def rejectMarshalling(supported: Seq[ContentType]): Unit = underlying.rejectMarshalling(supported)
+  def marshalTo(response: HttpResponse): Unit = underlying.marshalTo(response)
+  def handleError(error: Throwable): Unit = underlying.handleError(error)
+  def startChunkedMessage(response: HttpResponse, ack: Option[Any])(implicit sender: ActorRef): ActorRef =
+    underlying.startChunkedMessage(response, ack)
 }


### PR DESCRIPTION
For symmetry with normal `Marshaller` and for easier mapping over the responses produced by another `ToResponseMarshaller`.
