### PR TITLE
= can: only compact parser output ByteStrings (for HttpData), fixes #662

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/parsing/HttpHeaderParserSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/parsing/HttpHeaderParserSpec.scala
@@ -20,7 +20,7 @@ import java.lang.{ StringBuilder ⇒ JStringBuilder }
 import com.typesafe.config.{ ConfigFactory, Config }
 import org.specs2.mutable.Specification
 import akka.actor.ActorSystem
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.util.Utils._
 import spray.http.HttpHeaders._
 import spray.http.HttpHeader
@@ -259,10 +259,10 @@ class HttpHeaderParserSpec extends Specification {
       warnOnIllegalHeader = info ⇒ system.log.warning(info.formatPretty),
       unprimed = !primed)
     def insert(line: String, value: AnyRef): Unit =
-      if (parser.isEmpty) parser.insertRemainingCharsAsNewNodes(CompactByteString(line), value)()
-      else parser.insert(CompactByteString(line), value)()
+      if (parser.isEmpty) parser.insertRemainingCharsAsNewNodes(ByteString(line), value)()
+      else parser.insert(ByteString(line), value)()
 
-    def parseLine(line: String) = parser.parseHeaderLine(CompactByteString(line))() -> parser.resultHeader
+    def parseLine(line: String) = parser.parseHeaderLine(ByteString(line))() -> parser.resultHeader
 
     def parseAndCache(lineA: String)(lineB: String = lineA): HttpHeader = {
       val (ixA, headerA) = parseLine(lineA)

--- a/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
@@ -19,7 +19,7 @@ package spray.can.parsing
 import org.specs2.mutable.Specification
 import com.typesafe.config.{ ConfigFactory, Config }
 import scala.annotation.tailrec
-import akka.util.CompactByteString
+import akka.util.ByteString
 import akka.actor.ActorSystem
 import spray.util._
 import spray.http._
@@ -375,7 +375,7 @@ class RequestParserSpec extends Specification {
 
   def rawParse(parser: Parser)(rawRequest: String*): Seq[Any] = {
     def closeSymbol(close: Boolean) = if (close) 'close else 'dontClose
-    @tailrec def rec(current: Result, remainingData: List[CompactByteString], result: Seq[Any] = Seq.empty): Seq[Any] =
+    @tailrec def rec(current: Result, remainingData: List[ByteString], result: Seq[Any] = Seq.empty): Seq[Any] =
       current match {
         case Result.Emit(HttpRequest(m, u, h, e, p), c, continue) ⇒
           rec(continue(), remainingData, result ++ Seq(m, u, p, h, e.asString, closeSymbol(c)))
@@ -391,7 +391,7 @@ class RequestParserSpec extends Specification {
         case x                                 ⇒ Seq(x)
       }
 
-    val data: List[CompactByteString] = rawRequest.map(CompactByteString.apply)(collection.breakOut)
+    val data: List[ByteString] = rawRequest.map(ByteString.apply)(collection.breakOut)
     rec(parser(data.head), data.tail)
   }
 

--- a/spray-can-tests/src/test/scala/spray/can/parsing/ResponseParserSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/parsing/ResponseParserSpec.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.{ ConfigFactory, Config }
 import org.specs2.mutable.Specification
 import scala.annotation.tailrec
 import akka.actor.ActorSystem
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.util._
 import spray.http._
 import HttpHeaders._
@@ -236,7 +236,7 @@ class ResponseParserSpec extends Specification {
 
   def rawParse(parser: Parser)(rawResponse: String*): Seq[Any] = {
     def closeSymbol(close: Boolean) = if (close) 'close else 'dontClose
-    @tailrec def rec(current: Result, remainingData: List[CompactByteString], result: Seq[Any] = Seq.empty): Seq[Any] =
+    @tailrec def rec(current: Result, remainingData: List[ByteString], result: Seq[Any] = Seq.empty): Seq[Any] =
       current match {
         case Result.Emit(HttpResponse(s, e, h, p), c, continue) ⇒
           rec(continue(), remainingData, result ++ Seq(s, e.asString, h, p, closeSymbol(c)))
@@ -252,7 +252,7 @@ class ResponseParserSpec extends Specification {
         case x                                     ⇒ result :+ x
       }
 
-    val data: List[CompactByteString] = rawResponse.map(CompactByteString.apply)(collection.breakOut)
+    val data: List[ByteString] = rawResponse.map(ByteString.apply)(collection.breakOut)
     rec(parser(data.head), data.tail)
   }
 

--- a/spray-can/src/main/scala/spray/can/client/ResponseParsing.scala
+++ b/spray-can/src/main/scala/spray/can/client/ResponseParsing.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import scala.collection.immutable.Queue
 import akka.io.Tcp
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.can.rendering.RequestPartRenderingContext
 import spray.can.Http
 import spray.can.parsing._
@@ -81,16 +81,16 @@ private object ResponseParsing {
           }
 
           val eventPipeline: EPL = {
-            case Tcp.Received(data: CompactByteString) ⇒ processReceivedData(data)
+            case Tcp.Received(data) ⇒ processReceivedData(data)
 
             case ev @ Http.PeerClosed ⇒
-              processReceivedData(CompactByteString.empty)
+              processReceivedData(ByteString.empty)
               eventPL(ev)
 
             case ev ⇒ eventPL(ev)
           }
 
-          def processReceivedData(data: CompactByteString): Unit =
+          def processReceivedData(data: ByteString): Unit =
             try handleParsingResult(parser(data))
             catch {
               case NonFatal(e) ⇒

--- a/spray-can/src/main/scala/spray/can/parsing/CharUtils.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/CharUtils.scala
@@ -17,7 +17,7 @@
 package spray.can.parsing
 
 import scala.collection.immutable.NumericRange
-import akka.util.CompactByteString
+import akka.util.ByteString
 import scala.annotation.tailrec
 import java.lang.{ StringBuilder ⇒ JStringBuilder }
 
@@ -69,10 +69,10 @@ private object CharUtils {
     case x                              ⇒ x.toString
   }
 
-  def byteChar(input: CompactByteString, ix: Int): Char =
+  def byteChar(input: ByteString, ix: Int): Char =
     if (ix < input.length) input(ix).toChar else throw NotEnoughDataException
 
-  def asciiString(input: CompactByteString, start: Int, end: Int): String = {
+  def asciiString(input: ByteString, start: Int, end: Int): String = {
     @tailrec def build(ix: Int = start, sb: JStringBuilder = new JStringBuilder(end - start)): String =
       if (ix == end) sb.toString else build(ix + 1, sb.append(input(ix).toChar))
     if (start == end) "" else build()

--- a/spray-can/src/main/scala/spray/can/parsing/HttpRequestPartParser.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/HttpRequestPartParser.scala
@@ -18,7 +18,7 @@ package spray.can.parsing
 
 import java.lang.{ StringBuilder ⇒ JStringBuilder }
 import scala.annotation.tailrec
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.http._
 import HttpMethods._
 import StatusCodes._
@@ -35,7 +35,7 @@ private[can] class HttpRequestPartParser(_settings: ParserSettings, rawRequestUr
   def copyWith(warnOnIllegalHeader: ErrorInfo ⇒ Unit): HttpRequestPartParser =
     new HttpRequestPartParser(settings, rawRequestUriHeader)(headerParser.copyWith(warnOnIllegalHeader))
 
-  def parseMessage(input: CompactByteString, offset: Int): Result = {
+  def parseMessage(input: ByteString, offset: Int): Result = {
     var cursor = parseMethod(input, offset)
     cursor = parseRequestTarget(input, cursor)
     cursor = parseProtocol(input, cursor)
@@ -44,7 +44,7 @@ private[can] class HttpRequestPartParser(_settings: ParserSettings, rawRequestUr
     else badProtocol
   }
 
-  def parseMethod(input: CompactByteString, cursor: Int): Int = {
+  def parseMethod(input: ByteString, cursor: Int): Int = {
     @tailrec def parseCustomMethod(ix: Int = 0, sb: JStringBuilder = new JStringBuilder(16)): Int =
       if (ix < 16) { // hard-coded maximum custom method length
         byteChar(input, cursor + ix) match {
@@ -83,7 +83,7 @@ private[can] class HttpRequestPartParser(_settings: ParserSettings, rawRequestUr
     }
   }
 
-  def parseRequestTarget(input: CompactByteString, cursor: Int): Int = {
+  def parseRequestTarget(input: ByteString, cursor: Int): Int = {
     val uriStart = cursor
     val uriEndLimit = cursor + settings.maxUriLength
 
@@ -107,7 +107,7 @@ private[can] class HttpRequestPartParser(_settings: ParserSettings, rawRequestUr
   def badProtocol = throw new ParsingException(HTTPVersionNotSupported)
 
   // http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-22#section-3.3
-  def parseEntity(headers: List[HttpHeader], input: CompactByteString, bodyStart: Int, clh: Option[`Content-Length`],
+  def parseEntity(headers: List[HttpHeader], input: ByteString, bodyStart: Int, clh: Option[`Content-Length`],
                   cth: Option[`Content-Type`], teh: Option[`Transfer-Encoding`], hostHeaderPresent: Boolean,
                   closeAfterResponseCompletion: Boolean): Result =
     if (hostHeaderPresent || protocol == HttpProtocols.`HTTP/1.0`) {

--- a/spray-can/src/main/scala/spray/can/parsing/SpecializedHeaderValueParsers.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/SpecializedHeaderValueParsers.scala
@@ -17,7 +17,7 @@
 package spray.can.parsing
 
 import scala.annotation.tailrec
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.http._
 import HttpHeaders._
 import CharUtils._
@@ -29,7 +29,7 @@ private object SpecializedHeaderValueParsers {
   def specializedHeaderValueParsers = Seq(ContentLengthParser)
 
   object ContentLengthParser extends HeaderValueParser("Content-Length", maxValueCount = 1) {
-    def apply(input: CompactByteString, valueStart: Int, warnOnIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
+    def apply(input: ByteString, valueStart: Int, warnOnIllegalHeader: ErrorInfo ⇒ Unit): (HttpHeader, Int) = {
       @tailrec def recurse(ix: Int = valueStart, result: Long = 0): (HttpHeader, Int) = {
         val c = byteChar(input, ix)
         if (isDigit(c) && result >= 0) recurse(ix + 1, result * 10 + c - '0')

--- a/spray-can/src/main/scala/spray/can/parsing/package.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/package.scala
@@ -16,12 +16,12 @@
 
 package spray.can
 
-import akka.util.CompactByteString
+import akka.util.ByteString
 import spray.util.SingletonException
 import spray.http._
 
 package object parsing {
-  private[can]type Parser = CompactByteString ⇒ Result
+  private[can]type Parser = ByteString ⇒ Result
 }
 
 package parsing {
@@ -32,7 +32,7 @@ package parsing {
     case class Emit(part: HttpMessagePart, closeAfterResponseCompletion: Boolean, continue: () ⇒ Result) extends Result
     case class Expect100Continue(continue: () ⇒ Result) extends Result
     case class ParsingError(status: StatusCode, info: ErrorInfo) extends Result
-    case object IgnoreAllFurtherInput extends Result with Parser { def apply(data: CompactByteString) = this }
+    case object IgnoreAllFurtherInput extends Result with Parser { def apply(data: ByteString) = this }
   }
 
   class ParsingException(val status: StatusCode, val info: ErrorInfo) extends RuntimeException(info.formatPretty) {

--- a/spray-can/src/main/scala/spray/can/server/RequestParsing.scala
+++ b/spray-can/src/main/scala/spray/can/server/RequestParsing.scala
@@ -19,7 +19,7 @@ package spray.can.server
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
 import akka.io.Tcp
-import akka.util.{ CompactByteString, ByteString }
+import akka.util.ByteString
 import spray.can.rendering.ResponsePartRenderingContext
 import spray.can.Http
 import spray.can.parsing._
@@ -83,7 +83,7 @@ private[can] object RequestParsing {
           val commandPipeline = commandPL
 
           val eventPipeline: EPL = {
-            case Tcp.Received(data: CompactByteString) ⇒
+            case Tcp.Received(data) ⇒
               try handleParsingResult(parser(data))
               catch {
                 case e: ExceptionWithErrorInfo ⇒ handleError(StatusCodes.BadRequest, e.info)


### PR DESCRIPTION
Contains several smaller breaking internal API changes. It shouldn't contain
public ones.
