### PR TITLE
! io: prevent `Terminated` dead letters from IO layer, fixes #704

### DIFF
--- a/spray-io-tests/src/test/scala/spray/io/SslTlsSupportSpec.scala
+++ b/spray-io-tests/src/test/scala/spray/io/SslTlsSupportSpec.scala
@@ -349,6 +349,7 @@ class SslTlsSupportSpec extends Specification with NoTimeConversions {
 
     class ConnectionActor[T <: (PipelineContext ⇒ Option[SSLEngine])](events: ActorRef, connection: ActorRef,
                                                                       connected: Tcp.Connected)(implicit engineProvider: T) extends ConnectionHandler {
+      context.watch(connection)
       val pipeline = frontend >> SslTlsSupport(128, publishSslSessionInfo, sslTraceLogging)
       def receive = running(connection, pipeline, createSslTlsContext[T](connected))
       def frontend: PipelineStage = new PipelineStage {


### PR DESCRIPTION
The breaking nature of this commit comes from the `ConnectionHandler::baseEventPipeline` receiving an additional `tcpConnection: ActorRef` parameter.
