### PR TITLE
= docs: add links from directive usages in examples to docs, fixes #703

### DIFF
--- a/project/SphinxSupport.scala
+++ b/project/SphinxSupport.scala
@@ -1,5 +1,6 @@
 import sbt._
 import Keys._
+import scala.util.matching.Regex
 import Utils._
 
 
@@ -7,6 +8,8 @@ object SphinxSupport {
 
   val sphinxScript = SettingKey[Option[File]]("sphinx-script", "The location of the sphinx-build script")
   val sphinxCompile = TaskKey[Seq[File]]("sphinx-compile", "Compile Sphinx documentation into /site resources")
+  val generateDirectivesMapTarget = SettingKey[File]("generate-directives-map-file")
+  val generateDirectivesMap = TaskKey[Seq[File]]("generate-directives-map", "Try to infer directives from source files")
 
   val settings = seq(
 
@@ -21,7 +24,13 @@ object SphinxSupport {
     sphinxCompile <<= (sphinxScript, sourceDirectory in sphinxCompile,
       target in sphinxCompile, version, state) map compileSphinxSources,
 
-    watchSources <++= (sourceDirectory in sphinxCompile) map { d => (d ***).get.map(_.getAbsoluteFile) }
+    watchSources <++= (sourceDirectory in sphinxCompile) map { d => (d ***).get.map(_.getAbsoluteFile) },
+
+    generateDirectivesMapTarget <<= (resourceManaged in Compile) / "theme/js/directives-map.js",
+
+    generateDirectivesMap <<= (scalaSource in Compile in Build.sprayRouting, generateDirectivesMapTarget).map(generateDirectivesMap),
+
+    (resourceGenerators in Compile) <+= generateDirectivesMap
   )
 
   def compileSphinxSources(script: Option[File], sourceDir: File, targetDir: File, v: String, state: State) = {
@@ -52,5 +61,55 @@ object SphinxSupport {
 
     val candidates = sys.env.get("SPHINX_PATH").toSeq ++ wellKnownSphinxLocations
     candidates.map(file).flatMap(existing).headOption
+  }
+
+  // a pattern for a directive definition of this kind: "def abc(): Directive ="
+  val DirectiveDefinition = """(?ms:(?:def|val)\s+(\w+)(?=[:(\[])[^=]*?[:⇒]\s*(?:Directive|\w*Route)[^=\n]*=)""".r
+  // a pattern for directives explicitly marked like this: "/* directive */ def abc() ="
+  val ExplicitDirectiveDefinition = """(?ms:/\* directive \*/\s*(?:def|val)\s+(\w+)(?=[:(\[]))""".r
+
+  /**
+   * Tries to extract a list of directive names from the source files at the well-known
+   * location spray-routing/src/main/scala/spray/routing/directives/???Directives.scala
+   */
+  def generateDirectivesMap(routingSourceDir: File, targetFile: File): Seq[File] = {
+    targetFile.getParentFile().mkdirs()
+    val fw = new java.io.FileWriter(targetFile)
+
+    case class DirectivesGroup(group: String, directives: Seq[String])
+
+    def findDirectivesFiles: Seq[File] = {
+      val packageDir = new File(routingSourceDir, "spray/routing/directives")
+      packageDir.listFiles().filter(_.getName.endsWith("Directives.scala")).toSeq
+    }
+    def readDirectivesFile(file: File): DirectivesGroup = {
+      val name = directivesGroupName(file.getName.dropRight(6) /* ".scala" */)
+
+      val source = IO.read(file)
+      def find(regexp: Regex): Seq[String] =
+        regexp.findAllIn(source).matchData.map(_.group(1)).toSeq.filterNot(x => x.startsWith("_") || x == "apply")
+
+      val directives = Seq(DirectiveDefinition, ExplicitDirectiveDefinition).flatMap(find).distinct
+
+      directives.foreach(println)
+      DirectivesGroup(name, directives)
+    }
+    def directivesGroupName(name: String): String =
+      name.split("(?=[A-Z])").drop(1).dropRight(1).map(_.toLowerCase).mkString("-")
+
+    def writeGroup(group: DirectivesGroup): Unit = {
+      fw.write("{\ngroup: '")
+      fw.write(group.group)
+      fw.write("',\nentries: '")
+      fw.write(group.directives.mkString(" "))
+      fw.write("'},\n")
+    }
+    val groups = findDirectivesFiles.map(readDirectivesFile).sortBy(_.group)
+
+    fw.write("window.DirectivesMap = [\n")
+    groups.foreach(writeGroup)
+    fw.write("];\n")
+    fw.close()
+    Seq(targetFile)
   }
 }

--- a/site/src/main/resources/theme/js/highlight-directives.js
+++ b/site/src/main/resources/theme/js/highlight-directives.js
@@ -1,0 +1,46 @@
+$(function() {
+    var versionRE = new RegExp('/documentation/([^/]*)/.*')
+    var match = versionRE.exec(document.location.pathname);
+
+    if (match) {
+        var version = match[1]; // capture group 1
+
+        var directives = [];
+        // convert directivesMap into a flat list of {group, name} entries, only called once per page
+        function init() {
+            for (var i in DirectivesMap) {
+                var group = DirectivesMap[i];
+                var entries = group.entries.split(' ');
+                for (var j in entries) {
+                    var d = entries[j];
+                    directives.push({
+                        group: group.group+'-directives',
+                        name: d
+                    });
+                }
+            }
+        }
+
+        function findDirective(name) {
+            for (var i in directives) {
+                var t = directives[i];
+                if (t.name === name)
+                    return t;
+            }
+        }
+        function directiveLinkTarget(directive) {
+            return '/documentation/'+version+'/spray-routing/'+directive.group+'/'+directive.name+'/';
+        }
+        init();
+
+        $('.highlight-scala .n').each(function(i, e) {
+            // crude heuristic to exclude false positives in "ctx.request.method" or "ctx.complete"
+            if (e.previousSibling && e.previousSibling.textContent === ".") return;
+            var ele = $(e);
+            var name = ele.text();
+            var directive = findDirective(name);
+            if (directive)
+                ele.wrap('<a href="'+directiveLinkTarget(directive)+'"/>');
+        });
+    }
+});

--- a/site/src/main/twirl/page.scala.html
+++ b/site/src/main/twirl/page.scala.html
@@ -33,6 +33,8 @@
     <script type="text/javascript">(function(H){H.className=H.className.replace(/\bno-js\b/,'js')})(document.documentElement)</script>
 
     <script type="text/javascript" src="/js/mentor.min.js"></script>
+    <script type="text/javascript" src="/js/directives-map.js"></script>
+    <script type="text/javascript" src="/js/highlight-directives.js"></script>
     @node.doc.meta.scriptList.map { script =>
       <script type="text/javascript" src="@script" charset="utf-8"></script>
     }

--- a/spray-routing/src/main/scala/spray/routing/directives/EncodingDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/EncodingDirectives.scala
@@ -57,7 +57,7 @@ trait EncodingDirectives {
   /**
    * Wraps its inner Route with encoding support using the given Encoder.
    */
-  def encodeResponse(magnet: EncodeResponseMagnet) = {
+  def encodeResponse(magnet: EncodeResponseMagnet): Directive0 = {
     import magnet._
     def applyEncoder = mapRequestContext { ctx ⇒
       @volatile var compressor: Compressor = null

--- a/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
@@ -26,13 +26,13 @@ trait FormFieldDirectives extends ToNameReceptaclePimps {
    * Rejects the request if the form field parameter matcher(s) defined by the definition(s) don't match.
    * Otherwise the field content(s) are extracted and passed to the inner route.
    */
-  def formField(fdm: FieldDefMagnet): fdm.Out = fdm()
+  /* directive */ def formField(fdm: FieldDefMagnet): fdm.Out = fdm()
 
   /**
    * Rejects the request if the form field parameter matcher(s) defined by the definition(s) don't match.
    * Otherwise the field content(s) are extracted and passed to the inner route.
    */
-  def formFields(fdm: FieldDefMagnet): fdm.Out = fdm()
+  /* directive */ def formFields(fdm: FieldDefMagnet): fdm.Out = fdm()
 
 }
 

--- a/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
@@ -41,13 +41,13 @@ trait ParameterDirectives extends ToNameReceptaclePimps {
    * Rejects the request if the query parameter matcher(s) defined by the definition(s) don't match.
    * Otherwise the parameter value(s) are extracted and passed to the inner route.
    */
-  def parameter(pdm: ParamDefMagnet): pdm.Out = pdm()
+  /* directive */ def parameter(pdm: ParamDefMagnet): pdm.Out = pdm()
 
   /**
    * Rejects the request if the query parameter matcher(s) defined by the definition(s) don't match.
    * Otherwise the parameter value(s) are extracted and passed to the inner route.
    */
-  def parameters(pdm: ParamDefMagnet): pdm.Out = pdm()
+  /* directive */ def parameters(pdm: ParamDefMagnet): pdm.Out = pdm()
 
 }
 


### PR DESCRIPTION
Two components:
- client-side javascript which adds the links
- build-component that tries to extract the set of directives a source
  file defines

The extraction works by a heuristic regexp that tries to distinguish directive
definitions against other definitions. Directives can explicitly be marked
as such by prefixing them with a block comment, `/* directive */`.
