### PR TITLE
= io: fix Tcp.SO.reuseAddress not being applied for outgoing connections, fixes #712

### DIFF
--- a/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
+++ b/spray-io/src/main/scala/akka/io/TcpOutgoingConnection.scala
@@ -30,8 +30,8 @@ private[io] class TcpOutgoingConnection(_tcp: TcpExt,
 
   context.watch(commander) // sign death pact
 
-  localAddress.foreach(channel.socket.bind)
   options.foreach(_.beforeConnect(channel.socket))
+  localAddress.foreach(channel.socket.bind)
   channelRegistry.register(channel, 0)
   timeout foreach context.setReceiveTimeout //Initiate connection timeout if supplied
 


### PR DESCRIPTION
Backport of akka/akka@6ebf6717c9db4c57d5b918342f578a6120e19b5a

See https://github.com/akka/akka/pull/1849
