### PR TITLE
Render Cookies as cookie-pairs in Cookie-headers

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpHeader.scala
+++ b/spray-http/src/main/scala/spray/http/HttpHeader.scala
@@ -237,6 +237,9 @@ object HttpHeaders {
 
   object Cookie extends ModeledCompanion {
     def apply(first: HttpCookie, more: HttpCookie*): Cookie = apply(first +: more)
+    implicit val cookieRenderer: Renderer[HttpCookie] = new Renderer[HttpCookie] {
+      def render[R <: Rendering](r: R, c: HttpCookie): r.type = r ~~ c.name ~~ '=' ~~ c.content
+    }
     implicit val cookiesRenderer: Renderer[Seq[HttpCookie]] =
       Renderer.seqRenderer(separator = "; ") // cache
   }

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -188,11 +188,18 @@ class HttpHeaderSpec extends Specification {
     }
 
     "Cookie" in {
-      "Cookie: SID=31d4d96e407aad42" =!= `Cookie`(HttpCookie("SID", "31d4d96e407aad42"))
-      "Cookie: SID=31d4d96e407aad42; lang=en>US" =!= `Cookie`(HttpCookie("SID", "31d4d96e407aad42"), HttpCookie("lang", "en>US"))
-      "Cookie: a=1;b=2" =!= `Cookie`(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
-      "Cookie: a=1 ;b=2" =!= `Cookie`(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
-      "Cookie: a=1; b=2" =!= `Cookie`(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
+      "Cookie: SID=31d4d96e407aad42" =!= Cookie(HttpCookie("SID", "31d4d96e407aad42"))
+      "Cookie: SID=31d4d96e407aad42; lang=en>US" =!= Cookie(HttpCookie("SID", "31d4d96e407aad42"), HttpCookie("lang", "en>US"))
+      "Cookie: a=1;b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
+      "Cookie: a=1 ;b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
+      "Cookie: a=1; b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
+      Cookie(HttpCookie("SID", "31d4d96e407aad42",
+        domain = Some("example.com"),
+        expires = Some(DateTime(2021, 6, 9, 10, 18, 14)),
+        path = Some("/hello"),
+        httpOnly = true,
+        extension = Some("fancyPants"),
+        secure = true)).toString === "Cookie: SID=31d4d96e407aad42"
     }
 
     "Date" in {


### PR DESCRIPTION
see http://tools.ietf.org/search/rfc6265#section-4.2

Currently all cookie attributes are rendered into a Cookie-header.

This patch makes the rendering symmetric to the [parsing](https://github.com/spray/spray/blob/master/spray-http/src/main/scala/spray/http/parser/CookieHeaders.scala#L32-L38).
