### PR TITLE
Ignore a configured system proxy in tests

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
@@ -40,6 +40,7 @@ class SprayCanClientSpec extends Specification with NoTimeConversions {
     akka.io.tcp.trace-logging = off
     spray.can.client.request-timeout = 500ms
     spray.can.client.response-chunk-aggregation-limit = 0
+    spray.can.client.proxy.http = none
     spray.can.host-connector.max-retries = 1
     spray.can.host-connector.idle-timeout = infinite
     spray.can.host-connector.client.request-timeout = 500ms

--- a/spray-client/src/test/scala/spray/client/HttpHostConnectorSpec.scala
+++ b/spray-client/src/test/scala/spray/client/HttpHostConnectorSpec.scala
@@ -41,7 +41,8 @@ class HttpHostConnectorSpec extends Specification with NoTimeConversions {
     akka.io.tcp.trace-logging = off
     spray.can.host-connector.max-retries = 4
     spray.can.client.request-timeout = 400ms
-    spray.can.client.user-agent-header = "RequestMachine"""")
+    spray.can.client.user-agent-header = "RequestMachine"
+    spray.can.client.proxy.http = none""")
   implicit val system = ActorSystem(Utils.actorSystemNameFrom(getClass), testConf)
   import system.dispatcher
   val (interface, port) = Utils.temporaryServerHostnameAndPort()

--- a/spray-client/src/test/scala/spray/client/RedirectionIntegrationSpec.scala
+++ b/spray-client/src/test/scala/spray/client/RedirectionIntegrationSpec.scala
@@ -32,6 +32,7 @@ class RedirectionIntegrationSpec extends Specification with NoTimeConversions {
         max-redirects = 5
       }
       server.remote-address-header = on
+      client.proxy.http = none
     }""")
   implicit val system = ActorSystem(Utils.actorSystemNameFrom(getClass), testConf)
   import system.dispatcher


### PR DESCRIPTION
This prevents possible existing proxy sysprops from getting picked up by client tests.
