### PR TITLE
fix incorrect dtd reference, and make servlet 3

### DIFF
--- a/examples/spray-servlet/simple-spray-servlet-server/src/main/webapp/WEB-INF/web.xml
+++ b/examples/spray-servlet/simple-spray-servlet-server/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0"?>
-
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-        "http://java.sun.com/dtd/web-app_2_4.dtd">
-
-<web-app>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
     <listener>
         <listener-class>spray.servlet.Initializer</listener-class>


### PR DESCRIPTION
Hi there,

I noticed that the sample web.xml is pulling in a dtd that is reference 2.4.  The example web.xml is using serlvet 3 specific elements (i.e. async-supported).  

I'm included a patch to the web.xml to make it reference servlet 3 spec xmlns.

cheers
/dom
