### PR TITLE
= docs: fix typo, closes #749

### DIFF
--- a/docs/documentation/spray-routing/key-concepts/big-picture.rst
+++ b/docs/documentation/spray-routing/key-concepts/big-picture.rst
@@ -42,7 +42,7 @@ service actor you can either mix in the ``HttpService`` trait and add this line 
 
     def actorRefFactory = context
 
-or, alternatively, derive your service actor from ``HttpServiceActor`` clas, which already defines the connecting
+or, alternatively, derive your service actor from ``HttpServiceActor`` class, which already defines the connecting
 ``def actorRefFactory = context`` for you.
 
 


### PR DESCRIPTION
Tremendous amount of effort to fix a one-character typo. Second try. There's got to be a better way.
