### PR TITLE
= http: refactor SslTlsSupport, permit send multiple frames

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
@@ -239,6 +239,7 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
           `HTTP/1.0` ! NONE ! NONE ! NONE ! true |
           `HTTP/1.0` ! Some("close") ! NONE ! NONE ! true |
           `HTTP/1.0` ! Some("Keep-Alive") ! NONE ! Some("Keep-Alive") ! false |
+          `HTTP/1.1` ! Some("Upgrade") ! Some("Upgrade") ! Some("Upgrade") ! false |
           `HTTP/1.1` ! NONE ! Some("close") ! Some("close") ! true |> {
             (reqProto, reqCH, resCH, renCH, close) ⇒
               render(

--- a/spray-can/src/main/scala/spray/can/rendering/RenderSupport.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/RenderSupport.scala
@@ -25,6 +25,7 @@ private object RenderSupport {
   val Chunked = "chunked".getAsciiBytes
   val KeepAlive = "Keep-Alive".getAsciiBytes
   val Close = "close".getAsciiBytes
+  val Upgrade = "Upgrade".getAsciiBytes
 
   def CrLf = Rendering.CrLf
 

--- a/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
@@ -71,6 +71,7 @@ private[can] trait ResponseRenderingComponent {
 
             case x: `Connection` ⇒
               val connectionHeader = if (connHeader eq null) x else Connection(x.tokens ++ connHeader.tokens)
+              if (x.hasUpgrade) render(x)
               renderHeaders(tail, contentLengthDefined, userContentType, connectionHeader)
 
             case x: RawHeader if x.lowercaseName == "content-type" ||

--- a/spray-http/src/main/scala/spray/http/HttpHeader.scala
+++ b/spray-http/src/main/scala/spray/http/HttpHeader.scala
@@ -209,6 +209,7 @@ object HttpHeaders {
     def renderValue[R <: Rendering](r: R): r.type = r ~~ tokens
     def hasClose = has("close")
     def hasKeepAlive = has("keep-alive")
+    def hasUpgrade = has("upgrade")
     @tailrec private def has(item: String, ix: Int = 0): Boolean =
       if (ix < tokens.length)
         if (tokens(ix) equalsIgnoreCase item) true


### PR DESCRIPTION
Sending multiple frames before receive ack is common scenario
in a websocket session
