### PR TITLE
Upgrade to shapeless 2.0.0-M1.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val akkaSlf4j     = "com.typesafe.akka"                       %%  "akka-slf4j"                  % "2.3.0"
   val akkaTestKit   = "com.typesafe.akka"                       %%  "akka-testkit"                % "2.3.0"
   val parboiled     = "org.parboiled"                           %%  "parboiled-scala"             % "1.1.6"
-  val shapeless     = "com.chuusai"                             %%  "shapeless"                   % "1.2.4"
+  val shapeless     = "com.chuusai"                             %%  "shapeless"                   % "2.0.0-M1" cross CrossVersion.full
   val scalatest     = "org.scalatest"                           %%  "scalatest"                   % "2.1.0"
   val specs2        = "org.specs2"                              %%  "specs2"                      % "2.3.10"
   val sprayJson     = "io.spray"                                %%  "spray-json"                  % "1.2.5"

--- a/spray-routing/src/main/scala/spray/routing/Prepender.scala
+++ b/spray-routing/src/main/scala/spray/routing/Prepender.scala
@@ -17,8 +17,9 @@
 package spray.routing
 
 import shapeless._
+import shapeless.ops.hlist.Prepend
 
-// TODO: check whether we can remove this additional layer on top of PrependAux
+// TODO: check whether we can remove this additional layer on top of Prepend.Aux
 trait Prepender[P <: HList, S <: HList] {
   type Out <: HList
   def apply(prefix: P, suffix: S): Out
@@ -30,7 +31,7 @@ object Prepender {
     def apply(prefix: P, suffix: S) = prefix
   }
 
-  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: PrependAux[P, S, Out0]) =
+  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: Prepend.Aux[P, S, Out0]) =
     new Prepender[P, S] {
       type Out = Out0
       def apply(prefix: P, suffix: S): Out = prepend(prefix, suffix)

--- a/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
@@ -18,6 +18,8 @@ package spray.routing
 package directives
 
 import shapeless._
+import shapeless.ops.hlist.Prepend
+import shapeless.ops.hlist.LeftFolder
 
 trait AnyParamDirectives {
   /**
@@ -79,10 +81,10 @@ object AnyParamDefMagnet2 {
   import FieldDefMagnet2.FieldDefMagnetAux
   import ParamDefMagnet2.ParamDefMagnetAux
 
-  implicit def forTuple[T <: Product, L <: HList, Out](implicit hla: HListerAux[T, L],
+  implicit def forTuple[T <: Product, L <: HList, Out](implicit hla: Generic.Aux[T, L],
                                                        apdma: AnyParamDefMagnet2[L]) =
     new AnyParamDefMagnet2[T] {
-      def apply(value: T) = apdma(hla(value))
+      def apply(value: T) = apdma(hla.to(value))
       type Out = apdma.Out
     }
 
@@ -97,7 +99,7 @@ object AnyParamDefMagnet2 {
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]],
                                                                  pdma: ParamDefMagnetAux[T, Directive[LB]],
-                                                                 ev: PrependAux[LA, LB, Out]) = {
+                                                                 ev: Prepend.Aux[LA, LB, Out]) = {
 
       // see https://groups.google.com/forum/?fromgroups=#!topic/spray-user/HGEEdVajpUw
       def fdmaWrapper(t: T): Directive[LB] = fdma(t).hflatMap {

--- a/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
@@ -19,6 +19,8 @@ package directives
 
 import shapeless._
 import spray.http._
+import shapeless.ops.hlist.LeftFolder
+import shapeless.ops.hlist.Prepend
 
 trait FormFieldDirectives extends ToNameReceptaclePimps {
 
@@ -108,8 +110,8 @@ object FieldDefMagnet2 extends ToNameReceptaclePimps {
 
   /************ tuple support ******************/
 
-  implicit def forTuple[T <: Product, L <: HList, Out0](implicit hla: HListerAux[T, L], fdma: FieldDefMagnetAux[L, Out0]) =
-    FieldDefMagnetAux[T, Out0](tuple ⇒ fdma(hla(tuple)))
+  implicit def forTuple[T <: Product, L <: HList, Out0](implicit hla: Generic.Aux[T, L], fdma: FieldDefMagnetAux[L, Out0]) =
+    FieldDefMagnetAux[T, Out0](tuple ⇒ fdma(hla.to(tuple)))
 
   /************ HList support ******************/
 
@@ -117,7 +119,7 @@ object FieldDefMagnet2 extends ToNameReceptaclePimps {
     FieldDefMagnetAux[L, f.Out](_.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
-    implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]], ev: PrependAux[LA, LB, Out]) =
+    implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =
       at[Directive[LA], T] { (a, t) ⇒ a & fdma(t) }
   }
 }

--- a/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
@@ -20,6 +20,9 @@ package directives
 import java.lang.IllegalStateException
 import shapeless._
 
+import shapeless.ops.hlist.LeftFolder
+import shapeless.ops.hlist.Prepend
+
 trait ParameterDirectives extends ToNameReceptaclePimps {
 
   /**
@@ -133,8 +136,8 @@ object ParamDefMagnet2 {
 
   /************ tuple support ******************/
 
-  implicit def forTuple[T <: Product, L <: HList, Out0](implicit hla: HListerAux[T, L], pdma: ParamDefMagnetAux[L, Out0]) =
-    ParamDefMagnetAux[T, Out0](tuple ⇒ pdma(hla(tuple)))
+  implicit def forTuple[T <: Product, L <: HList, Out0](implicit hla: Generic.Aux[T, L], pdma: ParamDefMagnetAux[L, Out0]) =
+    ParamDefMagnetAux[T, Out0](tuple ⇒ pdma(hla.to(tuple)))
 
   /************ HList support ******************/
 
@@ -142,7 +145,7 @@ object ParamDefMagnet2 {
     ParamDefMagnetAux[L, f.Out](_.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
-    implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit pdma: ParamDefMagnetAux[T, Directive[LB]], ev: PrependAux[LA, LB, Out]) =
+    implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit pdma: ParamDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =
       at[Directive[LA], T] { (a, t) ⇒ a & pdma(t) }
   }
 }


### PR DESCRIPTION
We build shapeless 2.0 in dbuild so I needed to update spray to that
version because shapeless 2.0 is not compatible with 1.x.

Main changes are around PrependAux -> Prepend.Aux,
HListerAux -> Generic.Aux and changes to package structure.
