### PR TITLE
Avoids suppression of PipelineException causes

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/ResponseTransformation.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/ResponseTransformation.scala
@@ -32,7 +32,9 @@ trait ResponseTransformation extends TransformerPipelineSupport {
       if (response.status.isSuccess)
         response.as[T] match {
           case Right(value) ⇒ value
-          case Left(error)  ⇒ throw new PipelineException(error.toString)
+          case Left(error: MalformedContent) ⇒
+            throw new PipelineException(error.errorMessage, error.cause.orNull)
+          case Left(error) ⇒ throw new PipelineException(error.toString)
         }
       else throw new UnsuccessfulResponseException(response)
 


### PR DESCRIPTION
When unmarshalling in the pipeline, MalformedContent exceptions were
converted to strings and set as the message for a PipelineException.
However, this suppresses the stacktrace of the underlying cause (if
there is one), making debugging a custom/delegate unmarshaller very
difficult.

This commit sets the cause of the PipelineException to that of the
MalformedContent exception (or null if it does not exist).
