### PR TITLE
Fix byteCount in HttpData when clear() is called

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpData.scala
+++ b/spray-http/src/main/scala/spray/http/HttpData.scala
@@ -378,7 +378,10 @@ object HttpData {
           append(x)
       }
 
-    def clear(): Unit = b.clear()
+    def clear(): Unit = {
+      b.clear()
+      _byteCount = 0
+    }
 
     def result(): HttpData =
       b.result().foldRight(Empty: HttpData) {


### PR DESCRIPTION
As far as I can tell, the "clear()" method on HttpData is never called. Maybe it should be deleted?

It did have a bug in it though: the length is not zeroed out.

