### PR TITLE
fix for non-BMP characters when encoding URIs

### DIFF
--- a/spray-http/src/test/scala/spray/http/UriSpec.scala
+++ b/spray-http/src/test/scala/spray/http/UriSpec.scala
@@ -18,6 +18,7 @@ package spray.http
 
 import org.specs2.mutable.Specification
 import spray.util.UTF8
+import java.nio.charset.Charset
 import Uri._
 
 class UriSpec extends Specification {
@@ -177,6 +178,8 @@ class UriSpec extends Specification {
       Path("abc///de") === "abc" :: '/' :: '/' :: '/' :: "de" :: Empty
       Path("/abc%2F") === Path / "abc/"
       Path("H%C3%A4ll%C3%B6") === """Hällö""" :: Empty
+      Path("/%F0%9F%92%A9") === Path / "\ud83d\udca9"
+      Path("/%00%ff%00%61", Charset.forName("UTF-16")) === Path / "ÿa"
       Path("/%2F%5C") === Path / """/\"""
       Path("/:foo:/") === Path / ":foo:" / ""
       Path("%2520").head === "%20"


### PR DESCRIPTION
Currently, the URL-encoder encodes the surrogate pairs of a non-BMP character instead of the character itself. For example, U+1F4A9 should be encoded as "%F0%9F%92%A9" but instead, each of its pairs ("\ud83d" and "\udca9") get encoded, producing a total of 6 bytes instead of 4.

The new approach uses the `codePointAt` API instead of `charAt` which returns an Integer of the unicode codepoint, instead of Char.
