### PR TITLE
Simpler decoding

### DIFF
--- a/spray-http/src/main/scala/spray/http/Uri.scala
+++ b/spray-http/src/main/scala/spray/http/Uri.scala
@@ -688,20 +688,14 @@ object Uri {
         val bytesCount = (lastPercentSignIndexPlus3 - ix) / 3
         val bytes = new Array[Byte](bytesCount)
 
-        @tailrec def decodeBytes(i: Int = 0, oredBytes: Int = 0): Int =
+        @tailrec def decodeBytes(i: Int = 0): String =
           if (i < bytesCount) {
             val byte = intValueOfHexWord(ix + 3 * i + 1)
             bytes(i) = byte.toByte
-            decodeBytes(i + 1, oredBytes | byte)
-          } else oredBytes
+            decodeBytes(i + 1)
+          } else new String(bytes, charset)
 
-        if ((decodeBytes() >> 7) != 0) { // if non-ASCII chars are present we need to involve the charset for decoding
-          sb.append(new String(bytes, charset))
-        } else {
-          @tailrec def appendBytes(i: Int = 0): Unit =
-            if (i < bytesCount) { sb.append(bytes(i).toChar); appendBytes(i + 1) }
-          appendBytes()
-        }
+        sb.append(decodeBytes())
         decode(string, charset, lastPercentSignIndexPlus3)(sb)
 
       case x ⇒ decode(string, charset, ix + 1)(sb.append(x))

--- a/spray-http/src/test/scala/spray/http/UriSpec.scala
+++ b/spray-http/src/test/scala/spray/http/UriSpec.scala
@@ -180,6 +180,7 @@ class UriSpec extends Specification {
       Path("H%C3%A4ll%C3%B6") === """Hällö""" :: Empty
       Path("/%F0%9F%92%A9") === Path / "\ud83d\udca9"
       Path("/%00%ff%00%61", Charset.forName("UTF-16")) === Path / "ÿa"
+      Path("/%00%61%00%62%00%63", Charset.forName("UTF-16")) === Path / "abc"
       Path("/%2F%5C") === Path / """/\"""
       Path("/:foo:/") === Path / ":foo:" / ""
       Path("%2520").head === "%20"


### PR DESCRIPTION
This fix is on top of #855; when I was debugging a failing test I noticed the `decode` method had some problems; in particular some of the optimization assumptions only hold for character encodings that are "backwards compatible" with ASCII (i.e. Latin-1, UTF-8).

The resulting code is simpler but I'm not sure if it affected performance.

Filed this as a separate pull request from #855 incase you decide only supporting Latin-1/UTF-8/ASCII is fine (whereas #855 is unambiguously a bug).
