### PR TITLE
= util: remove unnecessary reflection in regex

### DIFF
--- a/spray-util/src/main/scala/spray/util/pimps/PimpedRegex.scala
+++ b/spray-util/src/main/scala/spray/util/pimps/PimpedRegex.scala
@@ -23,9 +23,7 @@ class PimpedRegex(regex: Regex) {
 
   def groupCount = {
     try {
-      val field = classOf[Pattern].getDeclaredField("capturingGroupCount")
-      field.setAccessible(true)
-      field.getInt(regex.pattern) - 1
+      regex.pattern.matcher("").groupCount()
     } catch {
       case t: Throwable ⇒
         throw new RuntimeException("Could not determine regex group count: " + regex.pattern.pattern, t)


### PR DESCRIPTION
Rather than reflecting on the pattern to get at the `capturingGroupCount` field (which does not exist on android and makes the routes blow up) we take the pattern and do a dummy match against an empty string, getting the `groupCount` from the result.

All the spray-routing tests passed, and trying it out in the console, the new snippet seems to do what I want. It also made my spray-on-android attempt get further in the boot process before blowing up on something else, so it solved my initial problem.
