### PR TITLE
Upgrade spray 1.3 to use shapeless 2.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
   val akkaSlf4j     = "com.typesafe.akka"                       %%  "akka-slf4j"                  % "2.3.2"
   val akkaTestKit   = "com.typesafe.akka"                       %%  "akka-testkit"                % "2.3.2"
   val parboiled     = "org.parboiled"                           %%  "parboiled-scala"             % "1.1.6"
-  val shapeless     = "com.chuusai"                             %%  "shapeless"                   % "1.2.4"
+  val shapeless     = "com.chuusai"                             %   "shapeless_2.10.4"            % "2.0.0"
   val scalatest     = "org.scalatest"                           %%  "scalatest"                   % "2.1.0"
   val specs2        = "org.specs2"                              %%  "specs2"                      % "2.3.10"
   val sprayJson     = "io.spray"                                %%  "spray-json"                  % "1.2.5"

--- a/spray-routing-tests/src/test/scala/spray/routing/FormFieldDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/FormFieldDirectivesSpec.scala
@@ -143,6 +143,7 @@ class FormFieldDirectivesSpec extends RoutingSpec {
     }
   }
   "The 'formField' requirement with deserializer directive" should {
+    implicit val forRVDRInt = spray.routing.directives.FieldDefMagnet2.forRVDR[Int]
     "block requests that do not contain the required formField" in {
       Get("/", urlEncodedForm) ~> {
         formFields('oldAge.as(Deserializer.HexInt) ! 78) { completeOk }

--- a/spray-routing-tests/src/test/scala/spray/routing/ParameterDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/ParameterDirectivesSpec.scala
@@ -16,7 +16,8 @@
 
 package spray.routing
 
-import shapeless.HNil
+import shapeless._
+import spray.routing.directives._
 
 class ParameterDirectivesSpec extends RoutingSpec {
 
@@ -42,6 +43,10 @@ class ParameterDirectivesSpec extends RoutingSpec {
     }
     "supply typed default values" in {
       Get() ~> {
+
+        implicit val forNDefRINt: ParamDefMagnet2.ParamDefMagnetAux[NameDefaultReceptacle[Int], Directive1[Int]] =
+          ParamDefMagnet2.forNDefR[Int]
+
         parameter('amount ? 45) { echoComplete }
       } ~> check { responseAs[String] === "45" }
     }
@@ -70,14 +75,25 @@ class ParameterDirectivesSpec extends RoutingSpec {
 
   "when used with 'as(HexInt)' the parameter directive" should {
     import spray.httpx.unmarshalling.FromStringDeserializers.HexInt
+
+    implicit val forNDesRInt: ParamDefMagnet2.ParamDefMagnetAux[NameDeserializerReceptacle[Int], Directive1[Int]] =
+      ParamDefMagnet2.forNDesR[Int]
+
+    implicit val forNDesROptInt: ParamDefMagnet2.ParamDefMagnetAux[NameDeserializerReceptacle[Option[Int]], Directive1[Option[Int]]] =
+      ParamDefMagnet2.forNDesR[Option[Int]]
+
+    implicit val forNDesDefRInt: ParamDefMagnet2.ParamDefMagnetAux[NameDeserializerDefaultReceptacle[Int], Directive1[Int]] =
+      ParamDefMagnet2.forNDesDefR[Int]
+
     "extract parameter values as Int" in {
       Get("/?amount=1f") ~> {
-        parameter('amount.as(HexInt)) { echoComplete }
+
+        parameter(ParamDefMagnet('amount.as(HexInt))) { echoComplete }
       } ~> check { responseAs[String] === "31" }
     }
     "cause a MalformedQueryParamRejection on illegal Int values" in {
       Get("/?amount=1x3") ~> {
-        parameter('amount.as(HexInt)) { echoComplete }
+        parameter(ParamDefMagnet('amount.as(HexInt))) { echoComplete }
       } ~> check {
         rejection must beLike {
           case MalformedQueryParamRejection("amount",
@@ -93,12 +109,12 @@ class ParameterDirectivesSpec extends RoutingSpec {
     "create typed optional parameters that" in {
       "extract Some(value) when present" in {
         Get("/?amount=A") ~> {
-          parameter("amount".as(HexInt)?) { echoComplete }
+          parameter(ParamDefMagnet("amount".as(HexInt)?)) { echoComplete }
         } ~> check { responseAs[String] === "Some(10)" }
       }
       "extract None when not present" in {
         Get() ~> {
-          parameter("amount".as(HexInt)?) { echoComplete }
+          parameter(ParamDefMagnet("amount".as(HexInt)?)) { echoComplete }
         } ~> check { responseAs[String] === "None" }
       }
       "cause a MalformedQueryParamRejection on illegal Int values" in {

--- a/spray-routing/src/main/scala/spray/routing/Prepender.scala
+++ b/spray-routing/src/main/scala/spray/routing/Prepender.scala
@@ -17,6 +17,7 @@
 package spray.routing
 
 import shapeless._
+import ops.hlist.Prepend
 
 // TODO: check whether we can remove this additional layer on top of PrependAux
 trait Prepender[P <: HList, S <: HList] {
@@ -30,7 +31,7 @@ object Prepender {
     def apply(prefix: P, suffix: S) = prefix
   }
 
-  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: PrependAux[P, S, Out0]) =
+  implicit def apply[P <: HList, S <: HList, Out0 <: HList](implicit prepend: Prepend.Aux[P, S, Out0]) =
     new Prepender[P, S] {
       type Out = Out0
       def apply(prefix: P, suffix: S): Out = prepend(prefix, suffix)


### PR DESCRIPTION
We followed the [shapeless migration guide](https://github.com/milessabin/shapeless/wiki/Migration-guide:-shapeless-1.2.4-to-2.0.0) to upgrade from 1.2.4 to 2.0.0. This compiles against scala version 2.10.4 and handles test compilation issues highlighted in [this](https://github.com/spray/spray/pull/837) PR.

We did however, run into some issues with implicit resolutions. See: 
- https://github.com/pellucidanalytics/spray/compare/release;1.3?expand=1#diff-8971335057f21287d86614b266549e08R79
- https://github.com/pellucidanalytics/spray/compare/release;1.3?expand=1#diff-8971335057f21287d86614b266549e08R47
