### PR TITLE
refs #869 Cookie: with ',' for separator

### DIFF
--- a/spray-http/src/main/scala/spray/http/parser/CookieHeaders.scala
+++ b/spray-http/src/main/scala/spray/http/parser/CookieHeaders.scala
@@ -30,7 +30,7 @@ private[parser] trait CookieHeaders {
   }
 
   def `*Cookie` = rule {
-    oneOrMore(CookiePair, separator = ";") ~ EOI ~~> (HttpHeaders.`Cookie`(_))
+    oneOrMore(CookiePair, separator = ";" | ",") ~ EOI ~~> (HttpHeaders.`Cookie`(_))
   }
 
   def CookiePair = rule {

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -212,6 +212,7 @@ class HttpHeaderSpec extends Specification {
       "Cookie: a=1;b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
       "Cookie: a=1 ;b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
       "Cookie: a=1; b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2"))
+      "Cookie: a=1,b=2" =!= Cookie(HttpCookie("a", "1"), HttpCookie("b", "2")).renderedTo("a=1; b=2")
       Cookie(HttpCookie("SID", "31d4d96e407aad42",
         domain = Some("example.com"),
         expires = Some(DateTime(2021, 6, 9, 10, 18, 14)),


### PR DESCRIPTION
Hi,

cookie can now be compliant with Jersey client :)
