### PR TITLE
+ routing: add `optionalAuthenticate` directive

### DIFF
--- a/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
+++ b/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
@@ -114,7 +114,7 @@ Directive                              Description
 :ref:`-onSuccess-`                     "Unwraps" a ``Future[T]`` and runs its inner route after future completion with
                                        the future's value as an extraction of type ``T``
 :ref:`-optionalAuthenticate-`          Tries to authenticate the user with a given authenticator and either extract a
-                                       an object representing the optional user context or rejects
+                                       an object representing the user context, extract `None`, or rejects
 :ref:`-optionalCookie-`                Extracts an ``HttpCookie`` with a given name, if the cookie is not present in the
                                        request extracts ``None``
 :ref:`-optionalHeaderValue-`           Extracts an optional HTTP header value using a given function

--- a/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
+++ b/docs/documentation/spray-routing/predefined-directives-alphabetically.rst
@@ -113,6 +113,8 @@ Directive                              Description
                                        with the future's failure exception as an extraction of type ``Throwable``
 :ref:`-onSuccess-`                     "Unwraps" a ``Future[T]`` and runs its inner route after future completion with
                                        the future's value as an extraction of type ``T``
+:ref:`-optionalAuthenticate-`          Tries to authenticate the user with a given authenticator and either extract a
+                                       an object representing the optional user context or rejects
 :ref:`-optionalCookie-`                Extracts an ``HttpCookie`` with a given name, if the cookie is not present in the
                                        request extracts ``None``
 :ref:`-optionalHeaderValue-`           Extracts an optional HTTP header value using a given function

--- a/docs/documentation/spray-routing/security-directives/index.rst
+++ b/docs/documentation/spray-routing/security-directives/index.rst
@@ -8,6 +8,7 @@ SecurityDirectives
 
    authenticate
    authorize
+   optionalAuthenticate
 
 Authentication vs. Authorization
 --------------------------------

--- a/docs/documentation/spray-routing/security-directives/optionalAuthenticate.rst
+++ b/docs/documentation/spray-routing/security-directives/optionalAuthenticate.rst
@@ -1,0 +1,26 @@
+.. _-optionalAuthenticate-:
+
+optionalAuthenticate
+====================
+
+Authenticates a request by checking credentials supplied in the request and extracts a value
+representing the authenticated principal.
+
+Signature
+---------
+
+::
+
+    def optionalAuthenticate[T](auth: ⇒ Future[Authentication[T]])(implicit executor: ExecutionContext): Directive1[Option[T]]
+    def optionalAuthenticate[T](auth: ContextAuthenticator[T])(implicit executor: ExecutionContext): Directive1[Option[T]]
+
+The signature shown is simplified, the real signature uses magnets. [1]_
+
+.. [1] See `The Magnet Pattern`_ for an explanation of magnet-based overloading.
+.. _`The Magnet Pattern`: /blog/2012-12-13-the-magnet-pattern/
+
+Description
+-----------
+
+The ``optionalAuthenticate`` directive is similar to the ``authenticate`` directive but always extracts an ``Option``
+value instead of rejecting the request if no credentials could be found.

--- a/docs/documentation/spray-routing/security-directives/optionalAuthenticate.rst
+++ b/docs/documentation/spray-routing/security-directives/optionalAuthenticate.rst
@@ -4,7 +4,7 @@ optionalAuthenticate
 ====================
 
 Authenticates a request by checking credentials supplied in the request and extracts a value
-representing the authenticated principal.
+representing the authenticated principal, or `None` if no credentials were supplied.
 
 Signature
 ---------

--- a/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
@@ -83,8 +83,6 @@ class SecurityDirectivesSpec extends RoutingSpec {
   }
 
   "the 'authenticate(<Future>)' directive" should {
-    case object AuthenticationRejection extends Rejection
-
     var i = 0
     def nextInt() = { i += 1; i }
     def myAuthenticator: Future[Authentication[Int]] = Future.successful(Right(nextInt()))
@@ -96,6 +94,68 @@ class SecurityDirectivesSpec extends RoutingSpec {
         check { responseAs[String] === "1" }
       Get() ~> Host("spray.io") ~> route ~>
         check { responseAs[String] === "2" }
+    }
+  }
+
+  "the 'optionalAuthenticate(BasicAuth())' directive" should {
+    "extract None from requests without Authorization header" in {
+      Get() ~> {
+        optionalAuthenticate(dontAuth) { echoComplete }
+      } ~> check { responseAs[String] === "None" }
+    }
+    "extract None from requests with Authorization header using a different scheme" in {
+      Get() ~> RawHeader("Authorization", "bob alice") ~> {
+        optionalAuthenticate(dontAuth) { echoComplete }
+      } ~> check { responseAs[String] === "None" }
+    }
+    "reject unauthenticated requests with Authorization header with an AuthenticationFailedRejection" in {
+      Get() ~> Authorization(BasicHttpCredentials("Bob", "")) ~> {
+        optionalAuthenticate(dontAuth) { echoComplete }
+      } ~> check { rejection === AuthenticationFailedRejection(CredentialsRejected, List(challenge)) }
+    }
+    "extract Some(object) representing the user identity created by successful authentication" in {
+      Get() ~> Authorization(BasicHttpCredentials("Alice", "")) ~> {
+        optionalAuthenticate(doAuth) { echoComplete }
+      } ~> check { responseAs[String] === "Some(BasicUserContext(Alice))" }
+    }
+    "properly handle exceptions thrown in its inner route" in {
+      object TestException extends spray.util.SingletonException
+      Get() ~> Authorization(BasicHttpCredentials("Alice", "")) ~> {
+        handleExceptions(ExceptionHandler.default) {
+          optionalAuthenticate(doAuth) { _ ⇒ throw TestException }
+        }
+      } ~> check { status === StatusCodes.InternalServerError }
+    }
+  }
+
+  "the 'optionalAuthenticate(<ContextAuthenticator>)' directive" should {
+    case object AuthenticationRejection extends Rejection
+
+    val myAuthenticator: ContextAuthenticator[Int] = ctx ⇒ Future {
+      Either.cond(ctx.request.uri.authority.host == Uri.NamedHost("spray.io"), 42, AuthenticationRejection)
+    }
+    "reject requests not satisfying the filter condition" in {
+      Get() ~> optionalAuthenticate(myAuthenticator) { echoComplete } ~>
+        check { rejection === AuthenticationRejection }
+    }
+    "pass on the authenticator extraction if the filter conditions is met" in {
+      Get() ~> Host("spray.io") ~> optionalAuthenticate(myAuthenticator) { echoComplete } ~>
+        check { responseAs[String] === "Some(42)" }
+    }
+  }
+
+  "the 'optionalAuthenticate(<Future>)' directive" should {
+    var i = 0
+    def nextInt() = { i += 1; i }
+    def myAuthenticator: Future[Authentication[Int]] = Future.successful(Right(nextInt()))
+
+    val route = optionalAuthenticate(myAuthenticator) { echoComplete }
+
+    "pass on the authenticator extraction if the filter conditions is met" in {
+      Get() ~> Host("spray.io") ~> route ~>
+        check { responseAs[String] === "Some(1)" }
+      Get() ~> Host("spray.io") ~> route ~>
+        check { responseAs[String] === "Some(2)" }
     }
   }
 }

--- a/spray-routing/src/main/scala/spray/routing/directives/SecurityDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/SecurityDirectives.scala
@@ -20,6 +20,7 @@ package directives
 import scala.concurrent.{ ExecutionContext, Future }
 import shapeless.HNil
 import spray.routing.authentication._
+import AuthenticationFailedRejection.CredentialsMissing
 import BasicDirectives._
 import FutureDirectives._
 import MiscDirectives._
@@ -32,6 +33,12 @@ trait SecurityDirectives {
    * Can be called either with a ``Future[Authentication[T]]`` or ``ContextAuthenticator[T]``.
    */
   def authenticate[T](magnet: AuthMagnet[T]): Directive1[T] = magnet.directive
+
+  /**
+   * Wraps its inner Route with optional authentication support.
+   * Can be called either with a ``Future[Authentication[T]]`` or ``ContextAuthenticator[T]``.
+   */
+  def optionalAuthenticate[T](magnet: AuthMagnet[T]): Directive1[Option[T]] = magnet.optionalDirective
 
   /**
    * Applies the given authorization check to the request.
@@ -51,6 +58,11 @@ trait SecurityDirectives {
 class AuthMagnet[T](authDirective: Directive1[Authentication[T]])(implicit executor: ExecutionContext) {
   val directive: Directive1[T] = authDirective.flatMap {
     case Right(user)     ⇒ provide(user)
+    case Left(rejection) ⇒ reject(rejection)
+  }
+  val optionalDirective: Directive1[Option[T]] = authDirective.flatMap {
+    case Right(user) ⇒ provide(Some(user))
+    case Left(AuthenticationFailedRejection(CredentialsMissing, _)) ⇒ provide(None)
     case Left(rejection) ⇒ reject(rejection)
   }
 }


### PR DESCRIPTION
- `optionalAuthenticate` directive provides `Some(userContext)` on
success, `None` if no credentials are provided, otherwise rejects