### PR TITLE
= routing: avoid logging users ldap passwords on error

### DIFF
--- a/spray-routing/src/main/scala/spray/routing/authentication/LdapAuthenticator.scala
+++ b/spray-routing/src/main/scala/spray/routing/authentication/LdapAuthenticator.scala
@@ -45,7 +45,7 @@ class LdapAuthenticator[T](config: LdapAuthConfig[T])(implicit ec: ExecutionCont
           authContext.close()
           config.createUserObject(entry)
         case Left(ex) ⇒
-          log.info("Could not authenticate credentials '{}'/'{}': {}", entry.fullName, pass, ex)
+          log.info("Could not authenticate user '{}': {}", entry.fullName, ex)
           None
       }
     }
@@ -73,7 +73,7 @@ class LdapAuthenticator[T](config: LdapAuthConfig[T])(implicit ec: ExecutionCont
           searchContext.close()
           result
         case Left(ex) ⇒
-          log.warning("Could not authenticate with search credentials '{}'/'{}': {}", searchUser, searchPass, ex)
+          log.warning("Could not authenticate with search user '{}': {}", searchUser, ex)
           None
       }
     }


### PR DESCRIPTION
This PR removes the logging of ldap passwords from the log files by the LdapAuthenticator.

We are using the LdapAuthenticator and had some networking issues with our Ldap server this morning. We noticed that the authenticator logs the users passwords in plaintext if there is an exception.
