### PR TITLE
Add documentation about how to use Spray compression

### DIFF
--- a/docs/documentation/spray-httpx/de-compression.rst
+++ b/docs/documentation/spray-httpx/de-compression.rst
@@ -6,8 +6,12 @@ The `HTTP spec`_ defines a ``Content-Encoding`` header, which signifies whether 
 text), are compression algorithms.
 
 Currently *spray* supports the compression and decompression of HTTP requests and responses with the ``gzip`` or
-``deflate`` encodings. The core logic for this, which is shared by the :ref:`spray-client` and :ref:`spray-routing`
+``deflate`` encodings.
+The core logic for this, which is shared by the :ref:`spray-client` and :ref:`spray-routing`
 modules for the client- and server-side (respectively), lives in the `spray.httpx.encoding`_ package.
+The support is not enabled by default, but must be explicitly requested.
+For server configuration, see :ref:WhenToUseWhichDecompressRequestDirective.
+For client configuration, see `spray.client.pipelining.decode` and `spray.httpx.ResponseTransformation`.
 
 .. _HTTP spec: http://www.w3.org/Protocols/rfc2616/rfc2616.html
 .. _spray.httpx.encoding: https://github.com/spray/spray/tree/release/1.1/spray-httpx/src/main/scala/spray/httpx/encoding


### PR DESCRIPTION
See https://groups.google.com/forum/#!msg/spray-user/gJBwvtNRI9o/gXnBFvTquT4J

Currently the Spray docs indicate "spray supports the compression and decompression of HTTP requests and responses", but don't mention that this isn't enabled by default, but must be explicitly requested.

