### PR TITLE
= http, httpx: Properly url encode fields from FormData

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicMarshallers.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/BasicMarshallers.scala
@@ -83,7 +83,7 @@ trait BasicMarshallers {
   implicit val FormDataMarshaller =
     Marshaller.delegate[FormData, String](`application/x-www-form-urlencoded`) { (formData, contentType) ⇒
       val charset = contentType.definedCharset getOrElse HttpCharsets.`UTF-8`
-      Uri.Query(formData.fields: _*).render(new StringRendering, charset.nioCharset).get
+      Uri.Query.asBodyData(formData.fields).render(new StringRendering, charset.nioCharset).get
     }
 
   implicit val ThrowableMarshaller = Marshaller[Throwable] { (value, ctx) ⇒ ctx.handleError(value) }

--- a/spray-httpx/src/test/scala/spray/httpx/FormFieldSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/FormFieldSpec.scala
@@ -49,6 +49,11 @@ class FormFieldSpec extends Specification {
         .flatMap(_.field("name").as[String]) === Right("Smith&Wesson")
     }
 
+    "properly encode the fields of www-urlencoded forms containing special chars" in {
+      marshal(FormData(Map("name" -> "Smith+Wesson; hopefully!")))
+        .right.map(_.asString) === Right("name=Smith%2BWesson%3B+hopefully%21")
+    }
+
     "properly allow access to the fields of multipart/form-data forms" in {
       marshal(multipartFormData)
         .flatMap(_.as[HttpForm])


### PR DESCRIPTION
When posting data using FormData the base sub-delimiters aren't URL encoded. For example a semi-colon is not converted to %3B. My assumption is that values containing delimiters passed to FormData aren't to be interpreted as such, that all reserved characters should be encoded.

I'm not sure if this is the best way to fix this, or if there's already a method I've missed, but it seemed to require the least amount of change.
