### PR TITLE
Encode sub delims in query parameters

### DIFF
--- a/spray-http/src/main/scala/spray/http/Uri.scala
+++ b/spray-http/src/main/scala/spray/http/Uri.scala
@@ -524,7 +524,7 @@ object Uri {
     }
     def render[R <: Rendering](r: R): r.type = render(r, UTF8)
     def render[R <: Rendering](r: R, charset: Charset): r.type = {
-      def enc(s: String): Unit = encode(r, s, charset, QUERY_FRAGMENT_CHAR & ~(AMP | EQUAL | PLUS), replaceSpaces = true)
+      def enc(s: String): Unit = encode(r, s, charset, QUERY_FRAGMENT_CHAR & ~(AMP | EQUAL | PLUS | SUB_DELIM), replaceSpaces = true)
       @tailrec def append(q: Query): r.type =
         q match {
           case Query.Empty ⇒ r

--- a/spray-http/src/test/scala/spray/http/UriSpec.scala
+++ b/spray-http/src/test/scala/spray/http/UriSpec.scala
@@ -265,6 +265,18 @@ class UriSpec extends Specification {
       Query() === Empty
       Query("k" -> "v") === ("k" -> "v") +: Empty
     }
+    "encode sub-delims used as query parameter values" in {
+      Query("a" -> "b=c").toString() === "a=b%3Dc"
+      Query("a" -> "b&c").toString() === "a=b%26c"
+      Query("a" -> "b+c").toString() === "a=b%2Bc"
+      Query("a" -> "b;c").toString() === "a=b%3Bc"
+    }
+    "encode sub-delims used as query parameter names" in {
+      Query("a=b" -> "c").toString() === "a%3Db=c"
+      Query("a&b" -> "c").toString() === "a%26b=c"
+      Query("a+b" -> "c").toString() === "a%2Bb=c"
+      Query("a;b" -> "c").toString() === "a%3Bb=c"
+    }
   }
 
   "URIs" should {


### PR DESCRIPTION
W3C recommends that frameworks accept a semicolon as a separator in query parameters, as well as `&`. For interoperability with frameworks that follow this suggestion, Spray should percent-encode any semicolons here in URLs that it renders, as they are intended as literal characters (and not separators).

Tests ensure that `a -> b;c` is encoded as `a=b%3Bc`, so another framework will treat it as `a -> b;c` rather than `a -> b, c -> ''`.

(In this case, the other framework is Play, but it's not the only framework with that behaviour.)
