### PR TITLE
= can: prevent URIs with non-http scheme earlier in request-level client API, fixes #879

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
@@ -440,6 +440,17 @@ class SprayCanClientSpec extends Specification with NoTimeConversions {
       probe.expectMsgType[Status.Failure].cause.getMessage must startWith("Cannot establish effective request URI")
     }
 
+    "produce an error if the request is missing a scheme" in {
+      val probe = TestProbe()
+      probe.send(IO(Http), Get("example.com:8080/abc"))
+      probe.expectMsgType[Status.Failure].cause.getMessage must startWith("requirement failed: Not a valid HTTP URI scheme: 'example.com'")
+    }
+    "produce an error if the request URI scheme isn't 'http' or 'https' one" in {
+      val probe = TestProbe()
+      probe.send(IO(Http), Get("blub:example.com:8080/abc"))
+      probe.expectMsgType[Status.Failure].cause.getMessage must startWith("requirement failed: Not a valid HTTP URI scheme: 'blub'")
+    }
+
     "produce an error if the request was not completed within the configured timeout" in new TestSetup {
       val probe = TestProbe()
       probe.send(IO(Http), Get("/abc") ~> Host(hostname, port))

--- a/spray-can/src/main/scala/spray/can/HttpManager.scala
+++ b/spray-can/src/main/scala/spray/can/HttpManager.scala
@@ -164,6 +164,8 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
     }
 
   def connectorForUri(uri: Uri) = {
+    require(uri.scheme == "http" || uri.scheme == "https",
+      s"Not a valid HTTP URI scheme: '${uri.scheme}' in '$uri'. (Did you forget http:// ?)")
     val host = uri.authority.host
     connectorFor(HostConnectorSetup(host.toString, uri.effectivePort, sslEncryption = uri.scheme == "https"))
   }


### PR DESCRIPTION
/cc @RichardBradley
