### PR TITLE
Extract multiple occurrences in the parameters/formFields directives by suffixing with .*

### DIFF
--- a/docs/documentation/spray-routing/form-field-directives/formFields.rst
+++ b/docs/documentation/spray-routing/form-field-directives/formFields.rst
@@ -25,7 +25,7 @@ Description
 
 Form fields can be either extracted as a String or can be converted to another type. The parameter name
 can be supplied either as a String or as a Symbol. Form field extraction can be modified to mark a field
-as required or optional or to filter requests where a form field has a certain value:
+as required, optional, or repeated, or to filter requests where a form field has a certain value:
 
 ``"color"``
     extract value of field "color" as ``String``
@@ -40,6 +40,13 @@ as required or optional or to filter requests where a form field has a certain v
     (see also :ref:`unmarshalling`)
 ``"amount".as(deserializer)``
     extract value of field "amount" with an explicit ``Deserializer``
+``"distance".*``
+    extract multiple occurrences of field "distance" as ``Iterable[String]``
+``"distance".as[Int].*``
+    extract multiple occurrences of field "distance" as ``Iterable[Int]``, you need a matching ``Deserializer`` in scope for that to work
+    (see also :ref:`unmarshalling`)
+``"distance".as[Int].*(HexInt)``
+    extract multiple occurrences of field "distance" as ``Iterable[Int]`` using the ``HexInt`` deserializer
 
 You can use :ref:`case-class-extraction` to group several extracted values together into a case-class
 instance.

--- a/docs/documentation/spray-routing/parameter-directives/index.rst
+++ b/docs/documentation/spray-routing/parameter-directives/index.rst
@@ -25,7 +25,7 @@ to use which shows properties of different parameter directives.
 directive                  level  ordering multi
 ========================== ====== ======== =====
 :ref:`-parameter-`         high   no       no
-:ref:`-parameters-`        high   no       no
+:ref:`-parameters-`        high   no       yes
 :ref:`-parameterMap-`      low    no       no
 :ref:`-parameterMultiMap-` low    no       yes
 :ref:`-parameterSeq-`      low    yes      yes

--- a/docs/documentation/spray-routing/parameter-directives/parameters.rst
+++ b/docs/documentation/spray-routing/parameter-directives/parameters.rst
@@ -24,7 +24,7 @@ Description
 -----------
 Query parameters can be either extracted as a String or can be converted to another type. The parameter name
 can be supplied either as a String or as a Symbol. Parameter extraction can be modified to mark a query parameter
-as required or optional or to filter requests where a parameter has a certain value:
+as required, optional, or repeated, or to filter requests where a parameter has a certain value:
 
 ``"color"``
     extract value of parameter "color" as ``String``
@@ -39,6 +39,13 @@ as required or optional or to filter requests where a parameter has a certain va
     (see also :ref:`unmarshalling`)
 ``"amount".as(deserializer)``
     extract value of parameter "amount" with an explicit ``Deserializer``
+``"distance".*``
+    extract multiple occurrences of parameter "distance" as ``Iterable[String]``
+``"distance".as[Int].*``
+    extract multiple occurrences of parameter "distance" as ``Iterable[Int]``, you need a matching ``Deserializer`` in scope for that to work
+    (see also :ref:`unmarshalling`)
+``"distance".as[Int].*(HexInt)``
+    extract multiple occurrences of parameter "distance" as ``Iterable[Int]`` using the ``HexInt`` deserializer
 
 You can use :ref:`case-class-extraction` to group several extracted values together into a case-class
 instance.
@@ -80,3 +87,15 @@ Deserialized parameter
 
 .. includecode:: ../code/docs/directives/ParameterDirectivesExamplesSpec.scala
    :snippet: mapped-value
+
+Repeated parameter
+++++++++++++++++++
+
+.. includecode:: ../code/docs/directives/ParameterDirectivesExamplesSpec.scala
+   :snippet: repeated
+
+Repeated, deserialized parameter
+++++++++++++++++++
+
+.. includecode:: ../code/docs/directives/ParameterDirectivesExamplesSpec.scala
+   :snippet: mapped-repeated

--- a/spray-httpx/src/test/scala/spray/httpx/FormFieldSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/FormFieldSpec.scala
@@ -36,17 +36,23 @@ class FormFieldSpec extends Specification {
     "properly allow access to the fields of www-urlencoded forms" in {
       marshal(formData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("surname").as[String]) === Right("Smith")
+        .flatMap(_.get("surname").as[String]) === Right("Smith")
 
       marshal(formData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("age").as[Int]) === Right(42)
+        .flatMap(_.get("age").as[Int]) === Right(42)
+    }
+
+    "properly allow access to the fields of www-urlencoded forms with multiple values" in {
+      marshal(FormData(Seq("age" -> "42", "city" -> "Chicago", "city" -> "Boston")))
+        .flatMap(_.as[HttpForm])
+        .map(_.getAll("city").map(_.rawValue.get)) === Right(Seq("Chicago", "Boston"))
     }
 
     "properly allow access to the fields of www-urlencoded forms containing special chars" in {
       marshal(FormData(Map("name" -> "Smith&Wesson")))
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("name").as[String]) === Right("Smith&Wesson")
+        .flatMap(_.get("name").as[String]) === Right("Smith&Wesson")
     }
 
     "properly encode the fields of www-urlencoded forms containing special chars" in {
@@ -57,17 +63,17 @@ class FormFieldSpec extends Specification {
     "properly allow access to the fields of multipart/form-data forms" in {
       marshal(multipartFormData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("surname").as[String]) === Right("Smith")
+        .flatMap(_.get("surname").as[String]) === Right("Smith")
 
       marshal(multipartFormData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("age").as[NodeSeq]) === Right(<int>42</int>)
+        .flatMap(_.get("age").as[NodeSeq]) === Right(<int>42</int>)
     }
 
     "return an error when accessing a field of www-urlencoded forms for which no FromStringOptionDeserializer is available" in {
       marshal(formData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("age").as[NodeSeq]) ===
+        .flatMap(_.get("age").as[NodeSeq]) ===
         Left(UnsupportedContentType("Expected 'text/xml' or 'application/xml' or 'text/html' or 'application/xhtml+xml' " +
           "but tried to read from application/x-www-form-urlencoded encoded field 'age' which provides only text/plain values."))
     }
@@ -75,7 +81,7 @@ class FormFieldSpec extends Specification {
     "return an error when accessing a field of multipart forms for which no Unmarshaller is available" in {
       marshal(multipartFormData)
         .flatMap(_.as[HttpForm])
-        .flatMap(_.field("age").as[Int]) ===
+        .flatMap(_.get("age").as[Int]) ===
         Left(UnsupportedContentType("Field 'age' can only be read from 'application/x-www-form-urlencoded' form content but was 'text/xml'"))
     }
   }

--- a/spray-routing-tests/src/test/scala/spray/routing/FormFieldDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/FormFieldDirectivesSpec.scala
@@ -159,4 +159,28 @@ class FormFieldDirectivesSpec extends RoutingSpec {
       } ~> check { response === Ok }
     }
   }
+  "The repeated 'formField' directive" should {
+    val urlEncodedFormWithRepeatedParams = FormData(Seq("age" -> "42", "hobby" -> ""))
+
+    "extract an empty Iterable when the parameter is absent" in {
+      Get("/", FormData(Seq("age" -> "42"))) ~> {
+        formFields('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List()" }
+    }
+    "extract all occurrences into an Iterable when parameter is present" in {
+      Get("/", FormData(Seq("age" -> "42", "hobby" -> "cooking", "hobby" -> "reading"))) ~> {
+        formFields('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List(cooking, reading)" }
+    }
+    "extract as Iterable[Int]" in {
+      Get("/", FormData(Seq("age" -> "42", "number" -> "3", "number" -> "5"))) ~> {
+        formFields('number.as[Int].*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 5)" }
+    }
+    "extract as Iterable[Int] with an explicit deserializer" in {
+      Get("/", FormData(Seq("age" -> "42", "number" -> "3", "number" -> "A"))) ~> {
+        formFields('number.as[Int].*(HexInt)) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 10)" }
+    }
+  }
 }

--- a/spray-routing-tests/src/test/scala/spray/routing/ParameterDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/ParameterDirectivesSpec.scala
@@ -183,4 +183,27 @@ class ParameterDirectivesSpec extends RoutingSpec {
     }
   }
 
+  "The repeated 'parameter' directive" should {
+    "extract an empty Iterable when the parameter is absent" in {
+      Get("/person?age=19") ~> {
+        parameter('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List()" }
+    }
+    "extract all occurrences into an Iterable when parameter is present" in {
+      Get("/person?age=19&hobby=cooking&hobby=reading") ~> {
+        parameter('hobby.*) { echoComplete }
+      } ~> check { responseAs[String] === "List(cooking, reading)" }
+    }
+    "extract as Iterable[Int]" in {
+      Get("/person?age=19&number=3&number=5") ~> {
+        parameter('number.as[Int].*) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 5)" }
+    }
+    "extract as Iterable[Int] with an explicit deserializer" in {
+      import spray.httpx.unmarshalling.FromStringDeserializers.HexInt
+      Get("/person?age=19&number=3&number=A") ~> {
+        parameter('number.as[Int].*(HexInt)) { echoComplete }
+      } ~> check { responseAs[String] === "List(3, 10)" }
+    }
+  }
 }

--- a/spray-routing/src/main/scala/spray/routing/directives/NameReceptacle.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/NameReceptacle.scala
@@ -16,7 +16,7 @@
 
 package spray.routing.directives
 
-import spray.httpx.unmarshalling.{ FromStringOptionDeserializer ⇒ FSOD, Deserializer }
+import spray.httpx.unmarshalling.{ FromStringDeserializer ⇒ FSD, FromStringOptionDeserializer ⇒ FSOD, Deserializer }
 
 trait ToNameReceptaclePimps {
   implicit def symbol2NR(symbol: Symbol) = new NameReceptacle[String](symbol.name)
@@ -29,6 +29,8 @@ case class NameReceptacle[A](name: String) {
   def ? = as[Option[A]]
   def ?[B](default: B) = NameDefaultReceptacle(name, default)
   def ![B](requiredValue: B) = RequiredValueReceptacle(name, requiredValue)
+  def * = RepeatedValueReceptacle[A](name)
+  def *(deserializer: FSD[A]) = RepeatedValueDeserializerReceptacle[A](name, deserializer)
 }
 
 case class NameDeserializerReceptacle[A](name: String, deserializer: FSOD[A]) {
@@ -41,6 +43,10 @@ case class NameDefaultReceptacle[A](name: String, default: A)
 
 case class RequiredValueReceptacle[A](name: String, requiredValue: A)
 
+case class RepeatedValueReceptacle[A](name: String)
+
 case class NameDeserializerDefaultReceptacle[A](name: String, deserializer: FSOD[A], default: A)
 
 case class RequiredValueDeserializerReceptacle[A](name: String, deserializer: FSOD[A], requiredValue: A)
+
+case class RepeatedValueDeserializerReceptacle[A](name: String, deserializer: FSD[A])


### PR DESCRIPTION
To extract an:
- `Iterable[String]`: `'amount.*`
- `Iterable[Int]`: `'amount.as[Int].*`
- `Iterable[Int]` with an explicit deserializer: `'amount.as[Int].*(HexInt)`

The explicit deserializer is a parameter of `*`, rather than `as[T]`, because it must be a `FromStringDeserializer`, rather than a `FromStringOptionDeserializer`, which only makes sense for repeated parameters. `'amount.as(HexInt).*` is a compile error.

More than happy to make any changes required to get this merged - in particular, I'd appreciate guidance on what to do about `FormFieldExtractor`, which required changes I'm not altogether satisfied with. In particular, I'm concerned about `getAll` returning a `Seq[FormField]` where each `FormField` has a `rawValue` of `Some` (and if the field is entirely absent, it returns an empty list), while `get` always returns a `FormField` whose `rawValue` is `None` if the field is absent. Essentially, `FormField` seems to be designed with an assumption of one-or-zero occurrences of the field.

This feature came in handy when implementing a geospatial HTTP-based standard called WCS (for the curious, the `subset` parameter of the `GetCoverage` request in the [spec](https://portal.opengeospatial.org/files/09-147r3)).