### PR TITLE
Adding Spray Session directives and Session Authentication

### DIFF
--- a/spray-routing-tests/src/test/resources/application.conf
+++ b/spray-routing-tests/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+akka {
+  loglevel = "DEBUG"
+}

--- a/spray-routing-tests/src/test/resources/application.conf
+++ b/spray-routing-tests/src/test/resources/application.conf
@@ -1,3 +1,0 @@
-akka {
-  loglevel = "DEBUG"
-}

--- a/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
@@ -113,11 +113,11 @@ class SecurityDirectivesSpec extends RoutingSpec {
       def verifyId(id: String): Option[Boolean] = {
         Some(id == userId)
       }
-      val session = Session.deserialize(Map("userId" -> userId))
-      println(Get("/rememberme") ~> addHeader(`Set-Cookie`(Session.encodeAsCookie(session))))
-      Get("/rememberme") ~> addHeader(`Set-Cookie`(Session.encodeAsCookie(session))) ~> {
+      //The key name `SPRAY-USER` is important as its the current default when no config is given.
+      val session = Session.deserialize(Map("SPRAY-USER" -> userId))
+      Get("/rememberme") ~> addHeader(Cookie(Session.encodeAsCookie(session))) ~> {
         authenticate(SessionLoginAuth(verifyId)) { foundUser ⇒ complete { foundUser.toString } }
-      } ~> check { responseAs[String] === true.toString }
+      } ~> check { responseAs[String] === Some(true).toString }
     }
   }
 }

--- a/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/SecurityDirectivesSpec.scala
@@ -24,13 +24,7 @@ import HttpHeaders._
 import AuthenticationFailedRejection._
 import spray.httpx.marshalling.Marshaller
 
-import org.junit.runner.RunWith
-import org.specs2.runner.JUnitRunner
-
-@RunWith(classOf[JUnitRunner])
 class SecurityDirectivesSpec extends RoutingSpec {
-
-  override def testConfigSource = """spray.session { }""".stripMargin
 
   val dontAuth = BasicAuth(UserPassAuthenticator[BasicUserContext](_ ⇒ Future.successful(None)), "Realm")
   val challenge = `WWW-Authenticate`(HttpChallenge("Basic", "Realm"))

--- a/spray-routing/src/main/scala/spray/routing/CookieBaker.scala
+++ b/spray-routing/src/main/scala/spray/routing/CookieBaker.scala
@@ -1,0 +1,240 @@
+package spray.routing
+
+import spray.http.HttpCookie
+import com.typesafe.config.{ Config, ConfigFactory }
+import akka.actor.ActorRefFactory
+import spray.util.{ actorSystem, Crypto, SettingsCompanion }
+import scala.concurrent.duration._
+
+/**
+ * Trait that should be extended by the Cookie helpers.
+ * This file was almost fully copied from the CookieBaker implementation
+ * in the Play! Framework.
+ */
+trait CookieBaker[T <: AnyRef] {
+
+  /**
+   * The cookie name.
+   */
+  def COOKIE_NAME: String
+
+  /**
+   * Default cookie, returned in case of error or if missing in the HTTP headers.
+   */
+  def emptyCookie: T
+
+  /**
+   * `true` if the Cookie is signed. Defaults to false.
+   */
+  def isSigned: Boolean = false
+
+  /**
+   * `true` if the Cookie should have the httpOnly flag, disabling access from Javascript. Defaults to true.
+   */
+  def httpOnly = true
+
+  /**
+   * The cookie expiration date in seconds, `None` for a transient cookie
+   */
+  def maxAge: Option[Long] = None
+
+  /**
+   * The cookie domain. Defaults to None.
+   */
+  def domain: Option[String] = None
+
+  /**
+   * `true` if the Cookie should have the secure flag, restricting usage to https. Defaults to false.
+   */
+  def secure = false
+
+  /**
+   *  The cookie path.
+   */
+  def path = "/"
+
+  /**
+   * Encodes the data as a `String`.
+   */
+  def encode(data: Map[String, String]): String = {
+    val encoded = data.map {
+      case (k, v) ⇒ java.net.URLEncoder.encode(k, "UTF-8") + "=" + java.net.URLEncoder.encode(v, "UTF-8")
+    }.mkString("&")
+    if (isSigned)
+      Crypto.sign(encoded) + "-" + encoded
+    else
+      encoded
+  }
+
+  /**
+   * Decodes from an encoded `String`.
+   */
+  def decode(data: String): Map[String, String] = {
+
+    def urldecode(data: String) = {
+      data
+        .split("&")
+        .map(_.split("=", 2))
+        .map(p ⇒ java.net.URLDecoder.decode(p(0), "UTF-8") -> java.net.URLDecoder.decode(p(1), "UTF-8"))
+        .toMap
+    }
+
+    // Do not change this unless you understand the security issues behind timing attacks.
+    // This method intentionally runs in constant time if the two strings have the same length.
+    // If it didn't, it would be vulnerable to a timing attack.
+    def safeEquals(a: String, b: String) = {
+      if (a.length != b.length) {
+        false
+      } else {
+        var equal = 0
+        for (i ← Array.range(0, a.length)) {
+          equal |= a(i) ^ b(i)
+        }
+        equal == 0
+      }
+    }
+
+    try {
+      if (isSigned) {
+        val splitted = data.split("-", 2)
+        val message = splitted.tail.mkString("-")
+        if (safeEquals(splitted(0), Crypto.sign(message)))
+          urldecode(message)
+        else
+          Map.empty[String, String]
+      } else urldecode(data)
+    } catch {
+      // fail gracefully is the session cookie is corrupted
+      case _: Exception ⇒ Map.empty[String, String]
+    }
+  }
+
+  /**
+   * Encodes the data as a `Cookie`.
+   */
+  def encodeAsCookie(data: T): HttpCookie = {
+    val cookie = encode(serialize(data))
+    println("HERE HERE: " + cookie)
+    HttpCookie(name = COOKIE_NAME, content = cookie, maxAge = maxAge, path = Some(path), domain = domain,
+      secure = secure, httpOnly = httpOnly)
+  }
+
+  /**
+   * Decodes the data from a `Cookie`.
+   */
+  def decodeFromCookie(cookie: Option[HttpCookie]): T = {
+    cookie.filter(_.name == COOKIE_NAME).map(c ⇒ deserialize(decode(c.value))).getOrElse(emptyCookie)
+  }
+
+  def discard = HttpCookie(name = COOKIE_NAME, content = "",
+    maxAge = Some(-1), path = Some(path),
+    domain = domain, secure = secure)
+
+  /**
+   * Builds the cookie object from the given data map.
+   *
+   * @param data the data map to build the cookie object
+   * @return a new cookie object
+   */
+  protected def deserialize(data: Map[String, String]): T
+
+  /**
+   * Converts the given cookie object into a data map.
+   *
+   * @param cookie the cookie object to serialize into a map
+   * @return a new `Map` storing the key-value pairs for the given cookie
+   */
+  protected def serialize(cookie: T): Map[String, String]
+
+}
+
+/**
+ * HTTP Session.
+ *
+ * Session data are encoded into an HTTP cookie, and can only contain simple `String` values.
+ */
+case class Session(data: Map[String, String] = Map.empty[String, String]) {
+
+  /**
+   * Optionally returns the session value associated with a key.
+   */
+  def get(key: String) = data.get(key)
+
+  /**
+   * Retruns true if the session has the given key.
+   */
+  def contains(key: String) = data.contains(key)
+
+  /**
+   * Returns `true` if this session is empty.
+   */
+  def isEmpty: Boolean = data.isEmpty
+
+  /**
+   * Adds a value to the session, and returns a new session.
+   *
+   * For example:
+   * {{{
+   * session + ("username" -> "bob")
+   * }}}
+   *
+   * @param kv the key-value pair to add
+   * @return the modified session
+   */
+  def +(kv: (String, String)) = {
+    require(kv._2 != null, "Cookie values cannot be null")
+    copy(data + kv)
+  }
+
+  /**
+   * Removes any value from the session.
+   *
+   * For example:
+   * {{{
+   * session - "username"
+   * }}}
+   *
+   * @param key the key to remove
+   * @return the modified session
+   */
+  def -(key: String) = copy(data - key)
+
+  /**
+   * Retrieves the session value which is associated with the given key.
+   */
+  def apply(key: String) = data(key)
+
+}
+case class SessionSettings(name: Option[String], secure: Option[Boolean], maxAge: Option[Long],
+                           httpOnly: Option[Boolean], path: Option[String], domain: Option[String])
+object SessionSettings extends SettingsCompanion[SessionSettings]("spray.session") {
+  def fromSubConfig(c: Config) = apply(readValue(c getString "name"),
+    readValue(c getBoolean "secure"),
+    readValue(c getLong "max-age"),
+    readValue(c getBoolean "http-only"),
+    readValue(c getString "path"),
+    readValue(c getString "domain"))
+
+  implicit def default(implicit refFactory: ActorRefFactory) =
+    apply(actorSystem)
+}
+
+/**
+ * Helper utilities to manage the Session cookie.
+ */
+object Session extends CookieBaker[Session] {
+  val sessionSettings = SessionSettings(ConfigFactory.load())
+  val COOKIE_NAME = sessionSettings.name.getOrElse("SPRAY_SESSION")
+  val emptyCookie = new Session
+  override val isSigned = true
+  override def secure = sessionSettings.secure.getOrElse(false)
+  override val maxAge = sessionSettings.maxAge.map(Duration(_, MILLISECONDS).toSeconds.toLong)
+
+  override val httpOnly = sessionSettings.httpOnly.getOrElse(true)
+  override def path = sessionSettings.path.getOrElse("/")
+  override def domain = sessionSettings.domain
+
+  def deserialize(data: Map[String, String]): Session = new Session(data)
+
+  def serialize(session: Session): Map[String, String] = session.data
+}

--- a/spray-routing/src/main/scala/spray/routing/CookieBaker.scala
+++ b/spray-routing/src/main/scala/spray/routing/CookieBaker.scala
@@ -114,7 +114,6 @@ trait CookieBaker[T <: AnyRef] {
    */
   def encodeAsCookie(data: T): HttpCookie = {
     val cookie = encode(serialize(data))
-    println("HERE HERE: " + cookie)
     HttpCookie(name = COOKIE_NAME, content = cookie, maxAge = maxAge, path = Some(path), domain = domain,
       secure = secure, httpOnly = httpOnly)
   }
@@ -123,7 +122,7 @@ trait CookieBaker[T <: AnyRef] {
    * Decodes the data from a `Cookie`.
    */
   def decodeFromCookie(cookie: Option[HttpCookie]): T = {
-    cookie.filter(_.name == COOKIE_NAME).map(c ⇒ deserialize(decode(c.value))).getOrElse(emptyCookie)
+    cookie.filter(_.name == COOKIE_NAME).map(c ⇒ deserialize(decode(c.content))).getOrElse(emptyCookie)
   }
 
   def discard = HttpCookie(name = COOKIE_NAME, content = "",

--- a/spray-routing/src/main/scala/spray/routing/authentication/SessionAuthenticator.scala
+++ b/spray-routing/src/main/scala/spray/routing/authentication/SessionAuthenticator.scala
@@ -1,0 +1,40 @@
+package spray.routing.authentication
+
+import scala.concurrent.{ ExecutionContext, Future }
+import spray.routing.{ RequestContext, Session, Rejection }
+import com.typesafe.config.{ Config, ConfigFactory }
+import spray.util.SettingsCompanion
+import akka.actor.ActorRefFactory
+import spray.util.actorSystem
+
+case class SessionAuthenticatorSettings(userKey: Option[String])
+object SessionAuthenticatorSettings extends SettingsCompanion[SessionAuthenticatorSettings]("spray.session") {
+  def fromSubConfig(c: Config) = apply(readValue(c getString "auth-key"))
+
+  implicit def default(implicit refFactory: ActorRefFactory) = apply(actorSystem)
+}
+
+/**
+ * An SessionAuthenticator is a UserSessionAuthenticator that uses a given session passed to the server from the client
+ * to authenticate the user and extract a user object.
+ */
+class SessionAuthenticator[U](findUser: String ⇒ Option[U])(implicit val executionContext: ExecutionContext) extends UserSessionAuthenticator[U] {
+
+  val sessionAuthenticatorSettings = SessionAuthenticatorSettings(ConfigFactory.load())
+  val userKey: String = sessionAuthenticatorSettings.userKey.getOrElse("SPRAY-USER")
+
+  def apply(session: Option[Session]): Future[Authentication[Option[U]]] = {
+    Future.successful {
+      Right(session.flatMap(_.get(userKey)).flatMap {
+        findUser(_)
+      })
+    }
+  }
+
+}
+
+object SessionLoginAuth {
+
+  def apply[T](findUser: String ⇒ Option[T])(implicit ec: ExecutionContext) = new SessionAuthenticator[T](findUser)
+
+}

--- a/spray-routing/src/main/scala/spray/routing/authentication/package.scala
+++ b/spray-routing/src/main/scala/spray/routing/authentication/package.scala
@@ -16,7 +16,8 @@
 
 package spray.routing
 
-import scala.concurrent.Future
+import scala.concurrent._
+import spray.routing.directives._
 
 package object authentication {
   //# auth-types
@@ -25,7 +26,8 @@ package object authentication {
   //#
   //# user-pass-authenticator
   type UserPassAuthenticator[T] = Option[UserPass] ⇒ Future[Option[T]]
-  //#
+  //# session authenticator
+  type UserSessionAuthenticator[T] = Option[Session] ⇒ Future[Authentication[Option[T]]]
 }
 
 package authentication {

--- a/spray-routing/src/main/scala/spray/routing/directives/SecurityDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/SecurityDirectives.scala
@@ -61,4 +61,9 @@ object AuthMagnet {
 
   implicit def fromContextAuthenticator[T](auth: ContextAuthenticator[T])(implicit executor: ExecutionContext): AuthMagnet[T] =
     new AuthMagnet(extract(auth).flatMap(onSuccess(_)))
+
+  import SessionDirectives._
+  implicit def fromSessionCookieAuthenticator[T](auth: UserSessionAuthenticator[T])(implicit executor: ExecutionContext): AuthMagnet[Option[T]] = {
+    new AuthMagnet(optionalSession.map(auth(_)).flatMap(onSuccess(_)))
+  }
 }

--- a/spray-routing/src/main/scala/spray/routing/directives/SessionDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/SessionDirectives.scala
@@ -1,0 +1,105 @@
+package spray.routing
+package directives
+
+import shapeless._
+import spray.routing._
+import scala.Some
+import shapeless.::
+import spray.routing.Session
+
+/**
+ * Taken from: https://github.com/azeem/spray-cookiebaker
+ */
+
+/**
+ * Rejection created when a given session value is not found
+ */
+case class MissingSessionRejection(valueName: String) extends Rejection
+
+trait SessionDirectives {
+  import directives.BasicDirectives._
+  import CookieDirectives._
+  import RouteDirectives._
+
+  /**
+   * Extracts and passes a baked cookie object from the cookie
+   * @param baker CookieBaker that can decode the cookie
+   */
+  def bakedCookie[T <: AnyRef](baker: CookieBaker[T]): Directive[T :: HNil] = cookie(baker.COOKIE_NAME).hmap {
+    case c :: HNil ⇒ baker.decodeFromCookie(Some(c))
+  }
+
+  /**
+   * Extracts and passes an Some of a baked cookie object from
+   * the cookie if it exists, otherwise None
+   * @param baker CookieBaker that can decode the baked cookie
+   */
+  def optionalBakedCookie[T <: AnyRef](baker: CookieBaker[T]): Directive[Option[T] :: HNil] =
+    bakedCookie(baker).hmap(_.map(shapeless.option)) | provide(None)
+
+  /**
+   * Encodes a Baked cookie and sets it in the response header
+   * @param baker CookieBaker that can encode the baked cookie
+   * @param data the baked cookie to be set
+   */
+  def setBakedCookie[T <: AnyRef](baker: CookieBaker[T], data: T): Directive0 = setCookie(baker.encodeAsCookie(data))
+
+  /**
+   * Clears a baked cookie in the response. By sending a discard cookie in
+   * the response
+   * @param baker CookieBaker that contains the discard cookie
+   */
+  def clearBakedCookie[T <: AnyRef](baker: CookieBaker[T]): Directive0 = setCookie(baker.discard)
+
+  /**
+   * Same as bakedCookie, using Session CookieBaker
+   */
+  def session: Directive[Session :: HNil] = bakedCookie(Session)
+
+  /**
+   * Extracts a Session value with the given name. Rejects MissingSessionRejection
+   * if the session value was not found
+   * @param name name of the session value
+   */
+  def sessionVal(name: String): Directive[String :: HNil] = session.hflatMap {
+    case s :: HNil if s.contains(name) ⇒ provide(s(name))
+    case _                             ⇒ reject(MissingSessionRejection(name))
+  }
+
+  /**
+   * Same as optionalBakedCookie, suing Session cookiebaker
+   * @return
+   */
+  def optionalSession: Directive[Option[Session] :: HNil] = optionalBakedCookie(Session)
+
+  /**
+   * Extracts and passes Some of session value with the given name.
+   * None if the session or the session value with given name was
+   * not found
+   * @param name name of the session value
+   */
+  def optionalSessionVal(name: String): Directive[Option[String] :: HNil] = optionalSession.hmap {
+    case Some(s) :: HNil ⇒ s.get(name)
+    case _               ⇒ None
+  }
+
+  /**
+   * Same as setBakedCookie with Session as the CookieBaker
+   * @param sessionData the Session objecompct to be set
+   */
+  def setSession(sessionData: Session): Directive0 = setBakedCookie(Session, sessionData)
+
+  /**
+   * Creates a session object from set of key value pairs and
+   * sets ut
+   * @param mapData set of (String, String) to create the session from
+   */
+  def setSession(mapData: (String, String)*): Directive0 = setSession(Session(Map(mapData: _*)))
+
+  /**
+   * Same as clearBakedCookie, using Session as the CookieBaker
+   */
+  def clearSession: Directive0 = clearBakedCookie(Session)
+}
+
+object SessionDirectives extends SessionDirectives

--- a/spray-util/src/main/scala/spray/util/Crypto.scala
+++ b/spray-util/src/main/scala/spray/util/Crypto.scala
@@ -1,0 +1,50 @@
+package spray.util
+
+import javax.crypto._
+import javax.crypto.spec.SecretKeySpec
+import com.typesafe.config.{ Config, ConfigFactory }
+import akka.actor.ActorRefFactory
+
+case class CryptoSettings(secretKey: Option[String])
+
+object CryptoSettings extends SettingsCompanion[CryptoSettings]("spray.util") {
+  def fromSubConfig(c: Config) = apply(readValue(c getString "secret-key"))
+
+  implicit def default(implicit refFactory: ActorRefFactory) =
+    apply(actorSystem)
+}
+
+trait Crypto {
+
+  def sign(message: String, key: Array[Byte]): String
+
+  def sign(message: String): String
+
+}
+
+object Crypto extends Crypto {
+
+  private lazy val secret: String = CryptoSettings(ConfigFactory.load()).secretKey getOrElse "SECRET-KEY-PLEASE-CHANGE"
+
+  def hex2bytes(hex: String): Array[Byte] = {
+    hex.replaceAll("[^0-9A-Fa-f]", "").sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+  }
+
+  def bytes2hex(bytes: Array[Byte], sep: Option[String] = None): String = {
+    sep match {
+      case None ⇒ bytes.map("%02x".format(_)).mkString
+      case _    ⇒ bytes.map("%02x".format(_)).mkString(sep.get)
+    }
+  }
+
+  override def sign(message: String, key: Array[Byte]): String = {
+    val mac = Mac.getInstance("HmacSHA1")
+    mac.init(new SecretKeySpec(key, "HmacSHA1"))
+    bytes2hex(mac.doFinal(message.getBytes("utf-8")))
+  }
+
+  override def sign(message: String): String = {
+    sign(message, secret.getBytes("utf-8"))
+  }
+
+}


### PR DESCRIPTION
Hello this is my first PR so please go easy on me :)

The following is a possible PR that includes new Session directives and a new Session Authentication context to be used with the authenticate directive (eg. remember-me feature on login). The implementation for: CookieJar was taken from the Play! Framework,  inspiration for the session directives were taken from: https://github.com/azeem/spray-cookiebaker and the Crypto functionality is also a stripped out version provided by the Play! Framework

At the moment because I'm not sure if this will go in, I've only included a single spec test to show proof of concept of "logging-in" a user based on session. If you think the change is good enough to make it in, I will go ahead and fill out all the remaining missing test cases.

Proposed commit message on squash:
```
= spray-routing spray-util spray-routing-tests: Added new session directive and session authentication 
```