### PR TITLE
Preserve order of headers during parse + minor cleanups

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/TestSupport.scala
+++ b/spray-can-tests/src/test/scala/spray/can/TestSupport.scala
@@ -49,17 +49,17 @@ object TestSupport {
   def response = HttpResponse(
     status = 200,
     headers = List(
-      `Content-Length`(0),
+      `Server`("spray/1.0"),
       `Date`(DateTime(2011, 8, 25, 9, 10, 29)),
-      `Server`("spray/1.0")))
+      `Content-Length`(0)))
 
   def response(content: String, additionalHeaders: HttpHeader*) = HttpResponse(
     status = 200,
-    headers = additionalHeaders.toList ::: List(
-      `Content-Type`(ContentTypes.`text/plain(UTF-8)`),
-      `Content-Length`(content.length),
+    headers = List(
+      `Server`("spray/1.0"),
       `Date`(DateTime(2011, 8, 25, 9, 10, 29)),
-      `Server`("spray/1.0")),
+      `Content-Length`(content.length),
+      `Content-Type`(ContentTypes.`text/plain(UTF-8)`)) ::: additionalHeaders.toList,
     entity = content)
 
   def rawResponse = prep {

--- a/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
@@ -77,20 +77,20 @@ class RequestParserSpec extends Specification {
              |Content-length:    17
              |
              |Shake your BOODY!"""
-        } === Seq(POST, Uri("/resource/yes"), `HTTP/1.0`, List(`Content-Length`(17), Connection("keep-alive"),
-          `User-Agent`("curl/7.19.7 xyz")), "Shake your BOODY!", 'dontClose)
+        } === Seq(POST, Uri("/resource/yes"), `HTTP/1.0`, List(`User-Agent`("curl/7.19.7 xyz"), Connection("keep-alive"),
+          `Content-Length`(17)), "Shake your BOODY!", 'dontClose)
       }
 
       "with a body and a `Transfer-Encoding: identity` header" in {
         parse {
           """|POST /resource/yes HTTP/1.1
-            |Transfer-Encoding: identity
-            |Content-length:    17
-            |Host: example.com
-            |
-            |Shake your BOODY!"""
+             |Transfer-Encoding: identity
+             |Content-length:    17
+             |Host: example.com
+             |
+             |Shake your BOODY!"""
         } === Seq(POST, Uri("/resource/yes"), `HTTP/1.1`,
-          List(Host("example.com"), `Content-Length`(17), `Transfer-Encoding`("identity")),
+          List(`Transfer-Encoding`("identity"), `Content-Length`(17), Host("example.com")),
           "Shake your BOODY!", 'dontClose)
       }
 
@@ -104,8 +104,8 @@ class RequestParserSpec extends Specification {
             |Shake your BOODY!GET / HTTP/1.0
             |
             |"""
-        } === Seq(POST, Uri("/resource/yes"), `HTTP/1.0`, List(`Content-Length`(17), Connection("keep-alive"),
-          `User-Agent`("curl/7.19.7 xyz")), "Shake your BOODY!", 'dontClose, GET, Uri("/"), `HTTP/1.0`, Nil, "", 'close)
+        } === Seq(POST, Uri("/resource/yes"), `HTTP/1.0`, List(`User-Agent`("curl/7.19.7 xyz"), Connection("keep-alive"),
+          `Content-Length`(17)), "Shake your BOODY!", 'dontClose, GET, Uri("/"), `HTTP/1.0`, Nil, "", 'close)
       }
 
       "with multi-line headers" in {
@@ -120,8 +120,8 @@ class RequestParserSpec extends Specification {
             |Content-type: application/json
             |
             |"""
-        } === Seq(DELETE, Uri("/abc"), `HTTP/1.0`, List(`Content-Type`(`application/json`), Connection("close", "fancy"),
-          Accept(MediaRanges.`*/*`), `User-Agent`("curl/7.19.7 abc xyz")), "", 'close)
+        } === Seq(DELETE, Uri("/abc"), `HTTP/1.0`, List(`User-Agent`("curl/7.19.7 abc xyz"), Accept(MediaRanges.`*/*`),
+          Connection("close", "fancy"), `Content-Type`(`application/json`)), "", 'close)
       }
 
       "byte-by-byte" in {
@@ -133,7 +133,7 @@ class RequestParserSpec extends Specification {
             |ABCDPATCH"""
         }
         rawParse(newParser)(request.toCharArray.map(_.toString)(collection.breakOut): _*) ===
-          Seq(PUT, Uri("/resource/yes"), `HTTP/1.1`, List(Host("x"), `Content-Length`(4)), "ABCD", 'dontClose)
+          Seq(PUT, Uri("/resource/yes"), `HTTP/1.1`, List(`Content-Length`(4), Host("x")), "ABCD", 'dontClose)
       }
 
       "with a custom HTTP method" in {
@@ -151,7 +151,7 @@ class RequestParserSpec extends Specification {
             |Host: x
             |
             |"""
-        } === Seq(PUT, Uri("/resource/yes"), `HTTP/1.1`, List(Host("x"), `Content-Length`(2147483649L)), 'dontClose)
+        } === Seq(PUT, Uri("/resource/yes"), `HTTP/1.1`, List(`Content-Length`(2147483649L), Host("x")), 'dontClose)
       }
       "with several identical `Content-Type` headers" in {
         parse {
@@ -166,7 +166,7 @@ class RequestParserSpec extends Specification {
           GET,
           Uri("/data"),
           `HTTP/1.1`,
-          List(`Content-Length`(0), `Content-Type`(`application/pdf`), Host("x")),
+          List(Host("x"), `Content-Type`(`application/pdf`), `Content-Length`(0)),
           "", 'dontClose)
       }
     }
@@ -180,8 +180,8 @@ class RequestParserSpec extends Specification {
           |Host: ping
           |
           |"""
-      val startMatch = Seq(PATCH, Uri("/data"), `HTTP/1.1`, List(Host("ping"),
-        `Content-Type`(`application/pdf`), Connection("lalelu"), `Transfer-Encoding`("chunked")), 'dontClose)
+      val startMatch = Seq(PATCH, Uri("/data"), `HTTP/1.1`, List(`Transfer-Encoding`("chunked"),
+        Connection("lalelu"), `Content-Type`(`application/pdf`), Host("ping")), 'dontClose)
 
       "request start" in {
         parse(start + "rest") === startMatch ++ Seq(400: StatusCode, "Illegal character 'r' in chunk start")
@@ -235,7 +235,7 @@ class RequestParserSpec extends Specification {
            |
            |"""
       def startMatch(contentSize: Int) =
-        Seq(GET, Uri("/data"), `HTTP/1.1`, List(`Content-Length`(contentSize), Host("ping"), `Content-Type`(`application/pdf`)))
+        Seq(GET, Uri("/data"), `HTTP/1.1`, List(`Content-Type`(`application/pdf`), Host("ping"), `Content-Length`(contentSize)))
 
       "full request if size < incoming-auto-chunking-threshold-size" in {
         parse(start(1) + "r") === startMatch(1) ++ Seq("r", 'dontClose)

--- a/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/RequestRendererSpec.scala
@@ -45,10 +45,10 @@ class RequestRendererSpec extends Specification {
       "GET request with a URI that requires encoding" in new TestSetup() {
         HttpRequest(GET, "/abc<def") must beRenderedTo {
           """|GET /abc%3Cdef HTTP/1.1
-            |Host: test.com:8080
-            |User-Agent: spray-can/1.0.0
-            |
-            |"""
+             |Host: test.com:8080
+             |User-Agent: spray-can/1.0.0
+             |
+             |"""
         }
       }
 
@@ -134,13 +134,13 @@ class RequestRendererSpec extends Specification {
             uri = "/abc/xyz",
             headers = List(RawHeader("Age", "30"), `Content-Type`(`text/plain`), `Content-Length`(1000)))) must beRenderedTo {
             """POST /abc/xyz HTTP/1.0
-            |Age: 30
-            |Content-Type: text/plain
-            |Content-Length: 1000
-            |Host: test.com:8080
-            |User-Agent: spray-can/1.0.0
-            |
-            |"""
+              |Age: 30
+              |Content-Type: text/plain
+              |Content-Length: 1000
+              |Host: test.com:8080
+              |User-Agent: spray-can/1.0.0
+              |
+              |"""
           }
       }
       "POST request start (chunkless chunk) without Content-Length must throw" in new TestSetup(chunklessStreaming = true) {

--- a/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
@@ -206,12 +206,12 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
             response = ChunkedResponseStart(HttpResponse(entity = "Yahoooo", headers = List(`Content-Length`(1000))))) === result {
               // no Connection: close header
               """HTTP/1.1 200 OK
-              |Server: spray-can/1.0.0
-              |Date: Thu, 25 Aug 2011 09:10:29 GMT
-              |Content-Length: 1000
-              |Content-Type: text/plain; charset=UTF-8
-              |
-              |Yahoooo"""
+                |Server: spray-can/1.0.0
+                |Date: Thu, 25 Aug 2011 09:10:29 GMT
+                |Content-Length: 1000
+                |Content-Type: text/plain; charset=UTF-8
+                |
+                |Yahoooo"""
             } -> false
           // but connection will still have to be closed afterwards
           render(ChunkedMessageEnd) === result("") -> true
@@ -219,9 +219,7 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
 
       "a chunkless response chunk" in new TestSetup(chunklessStreaming = true) {
         render(response = MessageChunk(HttpData("body123".getBytes),
-          """key=value;another="tl;dr"""")) === result {
-          "body123"
-        } -> false
+          """key=value;another="tl;dr"""")) === result("body123") -> false
       }
 
       "a chunkless final response chunk" in new TestSetup(chunklessStreaming = true) {

--- a/spray-can/src/main/scala/spray/can/parsing/HttpMessagePartParser.scala
+++ b/spray-can/src/main/scala/spray/can/parsing/HttpMessagePartParser.scala
@@ -17,6 +17,7 @@
 package spray.can.parsing
 
 import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
 import akka.util.ByteString
 import spray.http._
 import StatusCodes._
@@ -57,7 +58,8 @@ private[parsing] abstract class HttpMessagePartParser(val settings: ParserSettin
 
   def badProtocol: Nothing
 
-  @tailrec final def parseHeaderLines(input: ByteString, lineStart: Int, headers: List[HttpHeader] = Nil,
+  @tailrec final def parseHeaderLines(input: ByteString, lineStart: Int,
+                                      headers: ListBuffer[HttpHeader] = ListBuffer[HttpHeader](),
                                       headerCount: Int = 0, ch: Option[Connection] = None,
                                       clh: Option[`Content-Length`] = None, cth: Option[`Content-Type`] = None,
                                       teh: Option[`Transfer-Encoding`] = None, e100: Boolean = false,
@@ -76,37 +78,37 @@ private[parsing] abstract class HttpMessagePartParser(val settings: ParserSettin
     else headerParser.resultHeader match {
       case HttpHeaderParser.EmptyHeader ⇒
         val close = HttpMessage.connectionCloseExpected(protocol, ch)
-        val next = parseEntity(headers, input, lineEnd, clh, cth, teh, hh, close)
+        val next = parseEntity(headers.toList, input, lineEnd, clh, cth, teh, hh, close)
         if (e100) Result.Expect100Continue(() ⇒ next) else next
 
       case h: Connection ⇒
-        parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, Some(h), clh, cth, teh, e100, hh)
+        parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, Some(h), clh, cth, teh, e100, hh)
 
       case h: `Content-Length` ⇒
-        if (clh.isEmpty) parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, ch, Some(h), cth, teh, e100, hh)
+        if (clh.isEmpty) parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, ch, Some(h), cth, teh, e100, hh)
         else fail("HTTP message must not contain more than one Content-Length header")
 
       case h: `Content-Type` ⇒
-        if (cth.isEmpty) parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, ch, clh, Some(h), teh, e100, hh)
+        if (cth.isEmpty) parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, ch, clh, Some(h), teh, e100, hh)
         else if (cth.get == h) parseHeaderLines(input, lineEnd, headers, headerCount, ch, clh, cth, teh, e100, hh)
         else fail("HTTP message must not contain more than one Content-Type header")
 
       case h: `Transfer-Encoding` ⇒
-        parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, ch, clh, cth, Some(h), e100, hh)
+        parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, ch, clh, cth, Some(h), e100, hh)
 
       case h: Expect ⇒
-        if (h.has100continue) parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, ch, clh, cth, teh, e100 = true, hh)
+        if (h.has100continue) parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, ch, clh, cth, teh, e100 = true, hh)
         else fail(ExpectationFailed, s"Expectation '$h' is not supported by this server")
 
       case h if headerCount < settings.maxHeaderCount ⇒
-        parseHeaderLines(input, lineEnd, h :: headers, headerCount + 1, ch, clh, cth, teh, e100, hh || h.isInstanceOf[Host])
+        parseHeaderLines(input, lineEnd, headers += h, headerCount + 1, ch, clh, cth, teh, e100, hh || h.isInstanceOf[Host])
 
       case _ ⇒ fail(s"HTTP message contains more than the configured limit of ${settings.maxHeaderCount} headers")
     }
   }
 
   // work-around for compiler bug complaining about non-tail-recursion if we inline this method
-  def parseHeaderLinesAux(input: ByteString, lineStart: Int, headers: List[HttpHeader], headerCount: Int,
+  def parseHeaderLinesAux(input: ByteString, lineStart: Int, headers: ListBuffer[HttpHeader], headerCount: Int,
                           ch: Option[Connection], clh: Option[`Content-Length`], cth: Option[`Content-Type`],
                           teh: Option[`Transfer-Encoding`], e100: Boolean, hh: Boolean): Result =
     parseHeaderLines(input, lineStart, headers, headerCount, ch, clh, cth, teh, e100, hh)

--- a/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
@@ -61,9 +61,9 @@ private[can] trait ResponseRenderingComponent {
               renderHeaders(tail, contentLengthDefined, userContentType = userCT, connHeader)
 
             case x: `Content-Length` ⇒
-              if (contentLengthDefined) { suppressionWarning(x, "another `Content-Length` header was already rendered"); true }
-              else { render(x); true }
-              renderHeaders(tail, true, userContentType, connHeader)
+              if (contentLengthDefined) suppressionWarning(x, "another `Content-Length` header was already rendered")
+              else render(x)
+              renderHeaders(tail, contentLengthDefined = true, userContentType, connHeader)
 
             case `Transfer-Encoding`(_) | Date(_) | Server(_) ⇒
               suppressionWarning(head)


### PR DESCRIPTION
`List` prepend changed to `ListBuffer` append in `HttpMessagePartParser`.