### PR TITLE
= Issue #866: Fix the OSGi Import-Package version for scala.xml to use a...

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -140,7 +140,7 @@ object BuildSettings {
       },
       OsgiKeys.importPackage ++= imports,
       OsgiKeys.importPackage += "akka.spray.*;version=\"${Bundle-Version}\"",
-      OsgiKeys.importPackage += """akka.*;version="$<range;[==,=+);$<@>>"""",
+      OsgiKeys.importPackage += """akka.*;version="$<range;[==,=+)>"""",
       OsgiKeys.importPackage += "*",
       OsgiKeys.additionalHeaders := Map("-removeheaders" -> "Include-Resource,Private-Package")
     )


### PR DESCRIPTION
This patch is aimed to fix the 866 issue. It checks the scalaVersion and adds a specific scala.xml package version to the OSGI Import-Package header if the scalaVersion is greater or equal to 2.11.