### PR TITLE
= docs: sbt example - use scala version in artifactID

### DIFF
--- a/docs/project-info/maven-repository.rst
+++ b/docs/project-info/maven-repository.rst
@@ -32,7 +32,7 @@ All *spray* artifacts follow this naming scheme:
 So, for expressing a dependency on a *spray* module with SBT_ you'll want to add something like this
 to your project settings::
 
-  libraryDependencies += "io.spray" % "spray-can" % "1.0"
+  libraryDependencies += "io.spray" %% "spray-can" % "1.0"
 
 Make sure to replace the artifact name and version number with the one you are targeting! (see :ref:`Current Versions`)
 


### PR DESCRIPTION
the actual spray version (1.3.2) isn't under io/spray/spray-XXX/1.3.2
only under io/spray/spray-XXX_&lt;SCALA_VERSION&gt;/1.3.2
on the repos: repo1.maven.org and repo.spray.io