### PR TITLE
Implicits without the import tax" links fixed

### DIFF
--- a/docs/documentation/spray-httpx/marshalling.rst
+++ b/docs/documentation/spray-httpx/marshalling.rst
@@ -100,7 +100,7 @@ As another example, here is a ``Marshaller`` definition for a custom type ``Pers
 As can be seen in this example you best define the ``Marshaller`` for ``T`` in the companion object of ``T``.
 This way your marshaller is always in-scope, without any `import tax`_.
 
-.. _import tax: http://eed3si9n.com/revisiting-implicits-without-import-tax
+.. _import tax: http://vimeo.com/20308847
 
 
 Deriving Marshallers

--- a/docs/documentation/spray-httpx/unmarshalling.rst
+++ b/docs/documentation/spray-httpx/unmarshalling.rst
@@ -83,7 +83,7 @@ As another example, here is an ``Unmarshaller`` definition for a custom type ``P
 As can be seen in this example you best define the ``Unmarshaller`` for ``T`` in the companion object of ``T``.
 This way your unmarshaller is always in-scope, without any `import tax`_.
 
-.. _import tax: http://eed3si9n.com/revisiting-implicits-without-import-tax
+.. _import tax: http://vimeo.com/20308847
 
 
 Deriving Unmarshallers


### PR DESCRIPTION
The article linked to in the docs (revisiting implicits without import tax) does not provide good documentation on the pattern. It only goes through very detailed and overly complicated use cases.