### PR TITLE
= docs: fix wikipedia link

### DIFF
--- a/docs/documentation/spray-routing/key-concepts/big-picture.rst
+++ b/docs/documentation/spray-routing/key-concepts/big-picture.rst
@@ -60,4 +60,4 @@ thing, the ``runRoute`` wrapper. This method connects your route structure to th
 
 __  https://github.com/spray/spray/blob/master/spray-routing/src/main/scala/spray/routing/HttpService.scala
 .. _Unfiltered: http://unfiltered.databinder.net/
-.. _DRY: http://en.wikipedia.org/wiki/DRY
+.. _DRY: http://en.wikipedia.org/wiki/Don%27t_repeat_yourself


### PR DESCRIPTION
Changed file: spray/docs/documentation/spray-routing/key-concepts/big-picture.rst

Original link: http://en.wikipedia.org/wiki/DRY
New link: http://en.wikipedia.org/wiki/Don%27t_repeat_yourself