### PR TITLE
Use docker-based environment and dependency caching on Travis CI

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,7 +1,7 @@
 -Dfile.encoding=UTF8
 -XX:MaxPermSize=512m
 -Xms1g
--Xmx2g
+-Xmx3g
 -Xss2m
 -XX:+CMSClassUnloadingEnabled
 -XX:+UseConcMarkSweepGC

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
+# use Docker-based container (instead of OpenVZ)
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2/repository
+    - $HOME/.sbt
+    - $HOME/.ivy2
+
 language: scala
+
 script: 
-  - sbt ++$TRAVIS_SCALA_VERSION 'set concurrentRestrictions in Global += Tags.limit(Tags.Compile, 2)' compile test:compile
+  - sbt ++$TRAVIS_SCALA_VERSION compile test:compile
   - sbt ++$TRAVIS_SCALA_VERSION -Dakka.test.timefactor=1.5 'set concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)' test
+
+  # Trick to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+
 scala:
   - 2.10.3
+
 jdk:
   - oraclejdk7
   - openjdk7
+
 notifications:
   email:
     - johannes@spray.io


### PR DESCRIPTION
- faster VM boot time
- ability to cache dependencies in a free S3 storage
- 4G of RAM instead of 3G in OpenVZ container
- hopefully better parallelism performance (still to be proven)

Related to http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/