### PR TITLE
Documentation: Missing parameter type in directive

### DIFF
--- a/docs/documentation/spray-routing/range-directives/withRangeSupport.rst
+++ b/docs/documentation/spray-routing/range-directives/withRangeSupport.rst
@@ -13,7 +13,7 @@ Signature
 ::
 
     def withRangeSupport(): Directive0
-    def withRangeSupport(rangeCountLimit: Int, rangeCoalescingThreshold): Directive0
+    def withRangeSupport(rangeCountLimit: Int, rangeCoalescingThreshold:Long): Directive0
 
 The signature shown is simplified, the real signature uses magnets. [1]_
 


### PR DESCRIPTION
Just a tiny glitch in the withRangeSupport Documentation :)