### PR TITLE
Shapeless 2.1 Support (not for merge)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Build extends Build {
   // -------------------------------------------------------------------------------------------------------------------
 
   lazy val root = Project("root",file("."))
-    .aggregate(examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
+    .aggregate(docs, examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
       sprayIO, sprayIOTests, sprayRouting, sprayRoutingShapeless2, sprayRoutingTests, sprayRoutingShapeless2Tests, sprayServlet, sprayTestKit, sprayUtil)
     .settings(basicSettings: _*)
     .settings(noPublishing: _*)
@@ -213,6 +213,11 @@ object Build extends Build {
     .settings(SphinxSupport.settings: _*)
     .settings(docsSettings: _*)
     .settings(libraryDependencies ++= test(akkaActor, sprayJson), addSpecs2("test")) // , json4sNative))
+    .settings(
+      libraryDependencies ++= {
+        if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
+      }
+    )
 
 
   // -------------------------------------------------------------------------------------------------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -15,7 +15,7 @@ object Build extends Build {
   // -------------------------------------------------------------------------------------------------------------------
 
   lazy val root = Project("root",file("."))
-    .aggregate(docs, examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
+    .aggregate(examples, sprayCaching, sprayCan, sprayCanTests, sprayClient, sprayHttp, sprayHttpx,
       sprayIO, sprayIOTests, sprayRouting, sprayRoutingShapeless2, sprayRoutingTests, sprayRoutingShapeless2Tests, sprayServlet, sprayTestKit, sprayUtil)
     .settings(basicSettings: _*)
     .settings(noPublishing: _*)
@@ -141,6 +141,9 @@ object Build extends Build {
             val isExcluded = sourceWithShapeless2Changes(f.getName.toLowerCase)
             !(isExcluded && f.getAbsolutePath.contains("spray-routing/"))
           }
+        },
+        libraryDependencies ++= {
+          if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
         }
       )
 
@@ -160,7 +163,10 @@ object Build extends Build {
       .dependsOn(sprayRoutingShapeless2)
       .settings(
         unmanagedResourceDirectories in Test <++= (unmanagedResourceDirectories in Test in sprayRoutingTests),
-        unmanagedSourceDirectories in Test <<= (unmanagedSourceDirectories in Test in sprayRoutingTests)
+        unmanagedSourceDirectories in Test <<= (unmanagedSourceDirectories in Test in sprayRoutingTests),
+        libraryDependencies ++= {
+          if (scalaBinaryVersion.value startsWith "2.10") Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)) else Nil
+        }
       )
 
   lazy val sprayServlet = Project("spray-servlet", file("spray-servlet"))

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -10,7 +10,7 @@ import com.typesafe.sbt.osgi.SbtOsgi
 import SbtOsgi._
 
 object BuildSettings {
-  val VERSION = "1.3.2"
+  val VERSION = "1.3.2-shapeless21"
 
   lazy val basicSettings = seq(
     version               := NightlyBuildSupport.buildVersion(VERSION),
@@ -21,7 +21,7 @@ object BuildSettings {
                              "web services on top of Akka",
     startYear             := Some(2011),
     licenses              := Seq("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-    crossScalaVersions    := Seq("2.11.2", "2.10.4"),
+    crossScalaVersions    := Seq("2.11.4", "2.10.4"),
     resolvers             ++= Dependencies.resolutionRepos,
     scalacOptions         := Seq(
       "-encoding", "utf8",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
   }
 
   val addScalaReflect = libraryDependencies <+= scalaVersion("org.scala-lang" % "scala-reflect" % _ % "provided")
-  def addSpecs2(config: String) = libraryDependencies <+= scalaVersion(version => "org.specs2" %% "specs2" % specs2VersionPerScala(version) % config)
+  def addSpecs2(config: String) = libraryDependencies <+= scalaVersion(version => "org.specs2" %% "specs2" % specs2VersionPerScala(version) % config exclude ("org.scalamacros", "quasiquotes_2.10.3"))
 
   def specs2VersionPerScala(version: String): String = CrossVersion.partialVersion(version) match {
     case Some((2, 11)) => "2.3.13"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,8 +56,8 @@ object Dependencies {
   }
 
   val addShapeless2 = libraryDependencies <+= scalaVersion {
-    case x if x startsWith "2.11." => "com.chuusai" %% "shapeless" % "2.0.0"
-    case "2.10.4" => "com.chuusai" %% "shapeless" % "2.0.0" cross CrossVersion.full
+    case x if x startsWith "2.11." => "com.chuusai" %% "shapeless" % "2.1.0"
+    case "2.10.4" => "com.chuusai" %% "shapeless" % "2.1.0" cross CrossVersion.full
   }
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.7

--- a/spray-routing-shapeless2/src/main/scala/spray/routing/directives/Shapeless2Support.scala
+++ b/spray-routing-shapeless2/src/main/scala/spray/routing/directives/Shapeless2Support.scala
@@ -23,6 +23,14 @@ object AnyParamDefMagnet2 {
       }
     }
 
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    new AnyParamDefMagnet2[L] {
+      type Out = f.Out
+      def apply(value: L) = {
+        value.foldLeft(BasicDirectives.noop)(MapReduce)
+      }
+    }
+
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]],
                                                                  pdma: ParamDefMagnetAux[T, Directive[LB]],
@@ -51,6 +59,9 @@ trait LowLevelFieldDefMagnet2 {
 
   implicit def forHList[T, L <: HList](implicit hla: Generic.Aux[T, L], f: LeftFolder[L, Directive0, MapReduce.type]) =
     FieldDefMagnetAux[T, f.Out](t ⇒ hla.to(t).foldLeft(BasicDirectives.noop)(MapReduce))
+
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    FieldDefMagnetAux[L, f.Out](t ⇒ t.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit fdma: FieldDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =
@@ -120,6 +131,9 @@ trait LowLevelParamDefMagnet2 {
   /************ HList/tuple support ******************/
   implicit def forHList[T, L <: HList](implicit hla: Generic.Aux[T, L], f: LeftFolder[L, Directive0, MapReduce.type]) =
     ParamDefMagnetAux[T, f.Out](t ⇒ hla.to(t).foldLeft(BasicDirectives.noop)(MapReduce))
+
+  implicit def forIdentityHList[L <: HList](implicit f: LeftFolder[L, Directive0, MapReduce.type]) =
+    ParamDefMagnetAux[L, f.Out](l ⇒ l.foldLeft(BasicDirectives.noop)(MapReduce))
 
   object MapReduce extends Poly2 {
     implicit def from[T, LA <: HList, LB <: HList, Out <: HList](implicit pdma: ParamDefMagnetAux[T, Directive[LB]], ev: Prepend.Aux[LA, LB, Out]) =


### PR DESCRIPTION
This pull request is intended to show the minimal changes needed for Shapeless 2.1 support. It is not intended for merging.

The changes boil down to:
 - Fix conflicting quasiquotes dependency between Shapeless and specs2.
 - Add macro paradise plugin to 2.10 builds of projects using spray-routing-shapeless2.
 - Cope with the loss of `Generic.Aux[L, L] forSome { type L <: HList }` by defining alternate implicit witnesses for various magnets.

If you'd like, I can clean this up and open a new PR. If you'd like me to do that, let me know if you'd like to create another subproject, spray-routing-shapeless21, along with a similar test project.