### PR TITLE
= httpx: try to use safer default settings for the XML parser to prevent XXE attacks

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/unmarshalling/BasicUnmarshallers.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/unmarshalling/BasicUnmarshallers.scala
@@ -18,6 +18,8 @@ package spray.httpx.unmarshalling
 
 import java.nio.ByteBuffer
 import java.io.{ InputStreamReader, ByteArrayInputStream }
+import javax.xml.XMLConstants
+import javax.xml.parsers.{ SAXParser, SAXParserFactory }
 import scala.xml.{ XML, NodeSeq }
 import spray.http._
 import MediaTypes._
@@ -49,16 +51,37 @@ trait BasicUnmarshallers {
   implicit val NodeSeqUnmarshaller =
     Unmarshaller[NodeSeq](`text/xml`, `application/xml`, `text/html`, `application/xhtml+xml`) {
       case HttpEntity.NonEmpty(contentType, data) ⇒
-        val parser = XML.parser
-        try {
-          parser.setProperty("http://apache.org/xml/properties/locale", java.util.Locale.ROOT)
-        } catch {
-          case e: org.xml.sax.SAXNotRecognizedException ⇒ // property is not needed
-        }
-        XML.withSAXParser(parser).load(new InputStreamReader(new ByteArrayInputStream(data.toByteArray), contentType.charset.nioCharset))
+        XML.withSAXParser(createSAXParser())
+          .load(new InputStreamReader(new ByteArrayInputStream(data.toByteArray), contentType.charset.nioCharset))
       case HttpEntity.Empty ⇒ NodeSeq.Empty
     }
   //#
+
+  /**
+   * Provides a SAXParser for the NodeSeqUnmarshaller to use. Override to provide a custom SAXParser implementation.
+   * Will be called once for for every request to be unmarshalled. The default implementation calls [[createSaferSAXParser]].
+   * @return
+   */
+  protected def createSAXParser(): SAXParser = createSaferSAXParser()
+
+  /** Creates a safer SAXParser. */
+  protected def createSaferSAXParser(): SAXParser = {
+    val factory = SAXParserFactory.newInstance()
+    import com.sun.org.apache.xerces.internal.impl.Constants
+    import javax.xml.XMLConstants
+
+    factory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_GENERAL_ENTITIES_FEATURE, false)
+    factory.setFeature(Constants.SAX_FEATURE_PREFIX + Constants.EXTERNAL_PARAMETER_ENTITIES_FEATURE, false)
+    factory.setFeature(Constants.XERCES_FEATURE_PREFIX + Constants.DISALLOW_DOCTYPE_DECL_FEATURE, true)
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+    val parser = factory.newSAXParser()
+    try {
+      parser.setProperty("http://apache.org/xml/properties/locale", java.util.Locale.ROOT)
+    } catch {
+      case e: org.xml.sax.SAXNotRecognizedException ⇒ // property is not needed
+    }
+    parser
+  }
 }
 
 object BasicUnmarshallers extends BasicUnmarshallers

--- a/spray-httpx/src/test/scala/spray/httpx/unmarshalling/ScalaXmlUnmarshallerSpec.scala
+++ b/spray-httpx/src/test/scala/spray/httpx/unmarshalling/ScalaXmlUnmarshallerSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2011-2015 the spray project <http://spray.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * These tests have been ported from
+ * https://github.com/playframework/playframework/blob/656ee5a56bd7b2c7821d8dcb437688ae1deab1b7/framework/src/play/src/test/scala/play/libs/XMLSpec.scala
+ */
+package spray.httpx.unmarshalling
+
+import java.io.File
+
+import org.parboiled.common.FileUtils
+import org.specs2.execute.PendingUntilFixed
+import org.specs2.mutable.Specification
+import org.xml.sax.SAXParseException
+import spray.http.HttpEntity
+import spray.http.MediaTypes._
+
+import scala.xml.NodeSeq
+
+class ScalaXmlUnmarshallerSpec extends Specification with PendingUntilFixed {
+  "The ScalaXml (NodeSeq) unmarshaller" should {
+    "unmarshal XML bodies" in {
+      HttpEntity(`text/xml`, "<int>Hällö</int>").as[NodeSeq].right.get.text === "Hällö"
+    }
+    "parse XML bodies without loading in a related schema" in {
+      withTempFile("I shouldn't be there!") { f ⇒
+        val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
+                     | <!DOCTYPE foo [
+                     |   <!ELEMENT foo ANY >
+                     |   <!ENTITY xxe SYSTEM "${f.toURI}">]><foo>hello&xxe;</foo>""".stripMargin
+
+        HttpEntity(`text/xml`, xml).as[NodeSeq].left.get must beMalformedWithSAXParseException
+      }
+    }
+    "parse XML bodies without loading in a related schema from a parameter" in {
+      withTempFile("I shouldnt be there!") { generalEntityFile ⇒
+        withTempFile {
+          s"""<!ENTITY % xge SYSTEM "${generalEntityFile.toURI}">
+             |<!ENTITY % pe "<!ENTITY xxe '%xge;'>">""".stripMargin
+        } { parameterEntityFile ⇒
+          val xml = s"""<?xml version="1.0" encoding="ISO-8859-1"?>
+                       | <!DOCTYPE foo [
+                       |   <!ENTITY % xpe SYSTEM "${parameterEntityFile.toURI}">
+                       |   %xpe;
+                       |   %pe;
+                       |   ]><foo>hello&xxe;</foo>""".stripMargin
+          HttpEntity(`text/xml`, xml).as[NodeSeq].left.get must beMalformedWithSAXParseException
+        }
+      }
+    }
+    "gracefully fail when there are too many nested entities" in {
+      val nested = for (x ← 1 to 30) yield "<!ENTITY laugh" + x + " \"&laugh" + (x - 1) + ";&laugh" + (x - 1) + ";\">"
+      val xml =
+        s"""<?xml version="1.0"?>
+           | <!DOCTYPE billion [
+           | <!ELEMENT billion (#PCDATA)>
+           | <!ENTITY laugh0 "ha">
+           | ${nested.mkString("\n")}
+           | ]>
+           | <billion>&laugh30;</billion>""".stripMargin
+
+      HttpEntity(`text/xml`, xml).as[NodeSeq].left.get must beMalformedWithSAXParseException
+    }
+    "gracefully fail when an entity expands to be very large" in {
+      val as = "a" * 50000
+      val entities = "&a;" * 50000
+      val xml = s"""<?xml version="1.0"?>
+                  | <!DOCTYPE kaboom [
+                  | <!ENTITY a "$as">
+                  | ]>
+                  | <kaboom>$entities</kaboom>""".stripMargin
+      HttpEntity(`text/xml`, xml).as[NodeSeq].left.get must beMalformedWithSAXParseException
+    }
+  }
+
+  def beMalformedWithSAXParseException =
+    beLike[DeserializationError] {
+      case MalformedContent(_, Some(x: SAXParseException)) ⇒ ok
+    }
+
+  def withTempFile[T](content: String)(f: File ⇒ T): T = {
+    val file = File.createTempFile("xxe", ".txt")
+    try {
+      FileUtils.writeAllText(content, file)
+      f(file)
+    } finally {
+      file.delete()
+    }
+  }
+}


### PR DESCRIPTION
The tests are a direct port of the ones in playframework/playframework#3480.

The basic problem here is that there seems to be no standard way to ensure that the properties in question are supported by a given JDK (@jroper you seem to have additional information on that, would you care to comment?). In this form the fix worked for me on OpenJDK 7 on Linux but it isn't guaranteed that it will work elsewhere so if someone else could check with another JDK that would be great. (Run the tests in the spray-httpx subproject)

One "solution" would be to switch to an explicit xerces dependency and not relying on the existence of the JDK internal one. The escape hatch that I built in is that you can always override the `createSAXParser` method to customize the XML parser used. However, we need to make sure that class-loading doesn't fail if the internal classes are missing.