### PR TITLE
= http & can: add `Uri::toHttpRequestTargetOriginForm`, add double-slash...

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/client/SprayCanClientSpec.scala
@@ -434,6 +434,12 @@ class SprayCanClientSpec extends Specification with NoTimeConversions {
       verifyServerSideRequestAndReply(s"http://$hostname:$port/", probe)
     }
 
+    "support absolute request URIs with a double slash path component" in new TestSetup {
+      val probe = TestProbe()
+      probe.send(IO(Http), Get(s"http://$hostname:$port//foo"))
+      verifyServerSideRequestAndReply(s"http://$hostname:$port//foo", probe)
+    }
+
     "produce an error if the request does not contain a Host-header or an absolute URI" in {
       val probe = TestProbe()
       probe.send(IO(Http), Get("/abc"))

--- a/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/parsing/RequestParserSpec.scala
@@ -153,6 +153,7 @@ class RequestParserSpec extends Specification {
             |"""
         } === Seq(PUT, Uri("/resource/yes"), `HTTP/1.1`, List(`Content-Length`(2147483649L), Host("x")), 'dontClose)
       }
+
       "with several identical `Content-Type` headers" in {
         parse {
           """GET /data HTTP/1.1
@@ -168,6 +169,16 @@ class RequestParserSpec extends Specification {
           `HTTP/1.1`,
           List(Host("x"), `Content-Type`(`application/pdf`), `Content-Length`(0)),
           "", 'dontClose)
+      }
+
+      "with a request target starting with a double-slash" in {
+        parse {
+          """GET //foo?query=yes HTTP/1.0
+            |
+            |"""
+        } should beLike {
+          case Seq(GET, uri, `HTTP/1.0`, Nil, "", 'close) ⇒ uri.toString === "//foo?query=yes"
+        }
       }
     }
 

--- a/spray-can-tests/src/test/scala/spray/can/server/HttpServerConnectionPipelineSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/server/HttpServerConnectionPipelineSpec.scala
@@ -356,6 +356,19 @@ private class HttpServerConnectionPipelineSpec extends Specification with RawSpe
         "Please try again in a short while!"
       commands.expectMsg(Tcp.Close)
     }
+
+    "dispatch a request with a non-RFC3986 request-target to the service actor" in new MyFixture() {
+      val raw = prep {
+        """|GET //foo HTTP/1.1
+          |Host: test.com
+          |
+          |"""
+      }
+      connectionActor ! Tcp.Received(ByteString(raw))
+      commands.expectMsgPF() {
+        case Pipeline.Tell(`handlerRef`, msg, _) ⇒ msg
+      } === HttpRequest(uri = "http://test.com//foo", headers = List(`Host`("test.com")))
+    }
   }
 
   ///////////////////////// SUPPORT ////////////////////////

--- a/spray-can/src/main/scala/spray/can/HttpManager.scala
+++ b/spray-can/src/main/scala/spray/can/HttpManager.scala
@@ -45,7 +45,7 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
         val req = request.withEffectiveUri(securedConnection = false)
         val connector = connectorForUri(req.uri)
         // never render absolute URIs here and we also drop any potentially existing fragment
-        connector.forward(req.copy(uri = req.uri.toRelative.withoutFragment))
+        connector.forward(req.copy(uri = req.uri.toHttpRequestTargetOriginForm))
       } catch {
         case NonFatal(e) ⇒
           log.error("Illegal request: {}", e.getMessage)
@@ -56,7 +56,7 @@ private[can] class HttpManager(httpSettings: HttpExt#Settings) extends Actor wit
     case ctx @ RequestContext(req, _, _, commander) ⇒
       val connector = connectorForUri(req.uri)
       // never render absolute URIs here and we also drop any potentially existing fragment
-      val newReq = req.copy(uri = req.uri.toRelative.withoutFragment)
+      val newReq = req.copy(uri = req.uri.toHttpRequestTargetOriginForm)
       connector.tell(ctx.copy(request = newReq), commander)
 
     case (request: HttpRequest, setup: HostConnectorSetup) ⇒

--- a/spray-http/src/main/scala/spray/http/Uri.scala
+++ b/spray-http/src/main/scala/spray/http/Uri.scala
@@ -179,6 +179,16 @@ sealed abstract case class Uri(scheme: String, authority: Authority, path: Path,
     Uri(path = if (path.isEmpty) Uri.Path./ else path, query = query, fragment = fragment)
 
   /**
+   * Converts this URI into an HTTP request target "origin-form" as defined by
+   * https://tools.ietf.org/html/rfc7230#section-5.3.
+   *
+   * Note that the resulting URI instance is not a valid RFC 3986 URI! (As it might
+   * be a "relative" URI with a part component starting with a double slash.)
+   */
+  def toHttpRequestTargetOriginForm =
+    create("", Authority.Empty, if (path.isEmpty) Uri.Path./ else path, query, None)
+
+  /**
    * Drops the fragment from this URI
    */
   def withoutFragment =

--- a/spray-http/src/test/scala/spray/http/UriSpec.scala
+++ b/spray-http/src/test/scala/spray/http/UriSpec.scala
@@ -603,5 +603,10 @@ class UriSpec extends Specification {
       4450 === Uri("https://host/").withPort(4450).effectivePort
       4450 === Uri("https://host:3030/").withPort(4450).effectivePort
     }
+
+    "properly render as HTTP request target origin forms" in {
+      Uri("http://example.com/foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "/foo/bar?query=1"
+      Uri("http://example.com//foo/bar?query=1#frag").toHttpRequestTargetOriginForm.toString === "//foo/bar?query=1"
+    }
   }
 }


### PR DESCRIPTION
... path tests, closes #1019