### PR TITLE
= http: catch `IllegalArgumentException`s early when parsing headers, ...

### DIFF
--- a/spray-http/src/main/scala/spray/http/parser/HttpParser.scala
+++ b/spray-http/src/main/scala/spray/http/parser/HttpParser.scala
@@ -93,8 +93,8 @@ object HttpParser extends Parser with ProtocolParameterRules with AdditionalRule
     } catch {
       case e: ParserRuntimeException ⇒ e.getCause match {
         case e: IllegalUriException ⇒ Left(e.info)
-        case _: ParsingException    ⇒ Left(ErrorInfo.fromCompoundString(e.getCause.getMessage))
-        case x                      ⇒ throw x
+        case e @ (_: ParsingException | _: IllegalArgumentException) ⇒ Left(ErrorInfo.fromCompoundString(e.getMessage))
+        case x ⇒ throw x
       }
     }
   }

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -243,6 +243,7 @@ class HttpHeaderSpec extends Specification {
       "Host: [2001:db8::1]:8080" =!= Host("[2001:db8::1]", 8080)
       "Host: [2001:db8::1]" =!= Host("[2001:db8::1]")
       "Host: [::FFFF:129.144.52.38]" =!= Host("[::FFFF:129.144.52.38]")
+      "Host: spray.io:80000" =!= ErrorInfo("Illegal HTTP header 'Host': requirement failed", "Illegal port: 80000")
     }
 
     "If-Match" in {


### PR DESCRIPTION
... closes #992