### PR TITLE
= can: for unchunked responses to non-transparent HEAD requests let the ...

### DIFF
--- a/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
@@ -105,7 +105,7 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
         } -> false
       }
 
-      "a response to a transparent HEAD request" in new TestSetup() {
+      "an unchunked response to a transparent HEAD request" in new TestSetup() {
         render(requestMethod = HEAD,
           response = HttpResponse(
             headers = List(RawHeader("Age", "30"), Connection("Keep-Alive")),
@@ -121,7 +121,7 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
           } -> false
       }
 
-      "a response to a non-transparent HEAD request" in new TestSetup(transparentHeadRequests = false) {
+      "an unchunked response to a non-transparent HEAD request" in new TestSetup(transparentHeadRequests = false) {
         render(requestMethod = HEAD,
           response = HttpResponse(headers = List(RawHeader("Age", "30"),
             `Content-Type`(ContentTypes.`text/plain(UTF-8)`), `Content-Length`(100)))) === result {
@@ -131,6 +131,36 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
             |Age: 30
             |Content-Type: text/plain; charset=UTF-8
             |Content-Length: 100
+            |
+            |"""
+          } -> false
+      }
+
+      "a chunked response to a transparent HEAD request" in new TestSetup() {
+        render(requestMethod = HEAD,
+          response = ChunkedResponseStart(HttpResponse(
+            headers = List(RawHeader("Age", "30"), `Content-Type`(ContentTypes.`text/plain(UTF-8)`))))) === result {
+            """HTTP/1.1 200 OK
+            |Server: spray-can/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Age: 30
+            |Content-Type: text/plain; charset=UTF-8
+            |Transfer-Encoding: chunked
+            |
+            |"""
+          } -> false
+      }
+
+      "a chunked response to a non-transparent HEAD request" in new TestSetup(transparentHeadRequests = false) {
+        render(requestMethod = HEAD,
+          response = ChunkedResponseStart(HttpResponse(
+            headers = List(RawHeader("Age", "30"), `Content-Type`(ContentTypes.`text/plain(UTF-8)`))))) === result {
+            """HTTP/1.1 200 OK
+            |Server: spray-can/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Age: 30
+            |Content-Type: text/plain; charset=UTF-8
+            |Transfer-Encoding: chunked
             |
             |"""
           } -> false

--- a/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
+++ b/spray-can-tests/src/test/scala/spray/can/rendering/ResponseRendererSpec.scala
@@ -105,7 +105,7 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
         } -> false
       }
 
-      "a response to a HEAD request" in new TestSetup() {
+      "a response to a transparent HEAD request" in new TestSetup() {
         render(requestMethod = HEAD,
           response = HttpResponse(
             headers = List(RawHeader("Age", "30"), Connection("Keep-Alive")),
@@ -118,6 +118,21 @@ class ResponseRendererSpec extends mutable.Specification with DataTables {
               |Content-Length: 23
               |
               |"""
+          } -> false
+      }
+
+      "a response to a non-transparent HEAD request" in new TestSetup(transparentHeadRequests = false) {
+        render(requestMethod = HEAD,
+          response = HttpResponse(headers = List(RawHeader("Age", "30"),
+            `Content-Type`(ContentTypes.`text/plain(UTF-8)`), `Content-Length`(100)))) === result {
+            """HTTP/1.1 200 OK
+            |Server: spray-can/1.0.0
+            |Date: Thu, 25 Aug 2011 09:10:29 GMT
+            |Age: 30
+            |Content-Type: text/plain; charset=UTF-8
+            |Content-Length: 100
+            |
+            |"""
           } -> false
       }
 

--- a/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
+++ b/spray-can/src/main/scala/spray/can/rendering/ResponseRenderingComponent.scala
@@ -28,6 +28,7 @@ import RenderSupport._
 private[can] trait ResponseRenderingComponent {
   def serverHeaderValue: String
   def chunklessStreaming: Boolean
+  def transparentHeadRequests: Boolean
 
   private[this] val serverHeaderPlusDateColonSP =
     serverHeaderValue match {
@@ -107,11 +108,12 @@ private[can] trait ResponseRenderingComponent {
       import response._
       val close = renderResponseStart(response,
         allowUserContentType = entity.isEmpty && ctx.requestMethod == HttpMethods.HEAD,
-        contentLengthDefined = true)
+        contentLengthDefined = ctx.requestMethod != HttpMethods.HEAD || transparentHeadRequests)
       renderConnectionHeader(close)
 
-      // don't set a Content-Length header for non-keep-alive HTTP/1.0 responses (rely on body end by connection close)
-      if (response.protocol == `HTTP/1.1` || !close || ctx.requestMethod == HttpMethods.HEAD)
+      // don't set a Content-Length header for non-keep-alive HTTP/1.0 responses (rely on body end by connection close),
+      // however, for non-transparent HEAD requests let the user manage the header
+      if ((response.protocol == `HTTP/1.1` || !close) && (ctx.requestMethod != HttpMethods.HEAD || transparentHeadRequests))
         r ~~ `Content-Length` ~~ entity.data.length ~~ CrLf
       r ~~ CrLf
       if (entity.nonEmpty && ctx.requestMethod != HttpMethods.HEAD) r ~~ entity.data

--- a/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
+++ b/spray-can/src/main/scala/spray/can/server/ResponseRendering.scala
@@ -27,6 +27,7 @@ private object ResponseRendering {
     new PipelineStage with ResponseRenderingComponent {
       def serverHeaderValue: String = settings.serverHeader
       def chunklessStreaming: Boolean = settings.chunklessStreaming
+      def transparentHeadRequests: Boolean = settings.transparentHeadRequests
 
       def apply(context: PipelineContext, commandPL: CPL, eventPL: EPL): Pipelines =
         new Pipelines {


### PR DESCRIPTION
...user set `Content-Length`, closes #965