### PR TITLE
= http: Fixes mandatory quotation of realm, refs #1041

### DIFF
--- a/spray-http/src/main/scala/spray/http/HttpChallenge.scala
+++ b/spray-http/src/main/scala/spray/http/HttpChallenge.scala
@@ -20,7 +20,7 @@ case class HttpChallenge(scheme: String, realm: String,
                          params: Map[String, String] = Map.empty) extends ValueRenderable {
 
   def render[R <: Rendering](r: R): r.type = {
-    r ~~ scheme ~~ " realm=" ~~# realm
+    r ~~ scheme ~~ " realm=" ~~#! realm
     if (params.nonEmpty) params.foreach { case (k, v) ⇒ r ~~ ',' ~~ k ~~ '=' ~~# v }
     r
   }

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -327,7 +327,7 @@ class HttpHeaderSpec extends Specification {
     }
 
     "Proxy-Authenticate" in {
-      "Proxy-Authenticate: Basic realm=WallyWorld,attr=\"val>ue\", Fancy realm=yeah" =!=
+      "Proxy-Authenticate: Basic realm=\"WallyWorld\",attr=\"val>ue\", Fancy realm=\"yeah\"" =!=
         `Proxy-Authenticate`(HttpChallenge("Basic", "WallyWorld", Map("attr" -> "val>ue")), HttpChallenge("Fancy", "yeah"))
     }
 
@@ -380,10 +380,10 @@ class HttpHeaderSpec extends Specification {
     }
 
     "WWW-Authenticate" in {
-      "WWW-Authenticate: Basic realm=WallyWorld" =!=
+      "WWW-Authenticate: Basic realm=\"WallyWorld\"" =!=
         `WWW-Authenticate`(HttpChallenge("Basic", "WallyWorld"))
-      "WWW-Authenticate: BaSiC rEaLm=WallyWorld" =!=
-        `WWW-Authenticate`(HttpChallenge("BaSiC", "WallyWorld")).renderedTo("BaSiC realm=WallyWorld")
+      "WWW-Authenticate: BaSiC rEaLm=\"WallyWorld\"" =!=
+        `WWW-Authenticate`(HttpChallenge("BaSiC", "WallyWorld")).renderedTo("BaSiC realm=\"WallyWorld\"")
       "WWW-Authenticate: Basic realm=\"foo<bar\"" =!= `WWW-Authenticate`(HttpChallenge("Basic", "foo<bar"))
       """WWW-Authenticate: Digest
                            realm="testrealm@host.com",
@@ -393,7 +393,7 @@ class HttpHeaderSpec extends Specification {
         `WWW-Authenticate`(HttpChallenge("Digest", "testrealm@host.com", Map("qop" -> "auth,auth-int",
           "nonce" -> "dcd98b7102dd2f0e8b11d0f600bfb0c093", "opaque" -> "5ccc069c403ebaf9f0171e9517f40e41"))).renderedTo(
           "Digest realm=\"testrealm@host.com\",qop=\"auth,auth-int\",nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093,opaque=5ccc069c403ebaf9f0171e9517f40e41")
-      "WWW-Authenticate: Basic realm=WallyWorld,attr=\"val>ue\", Fancy realm=yeah" =!=
+      "WWW-Authenticate: Basic realm=\"WallyWorld\",attr=\"val>ue\", Fancy realm=\"yeah\"" =!=
         `WWW-Authenticate`(HttpChallenge("Basic", "WallyWorld", Map("attr" -> "val>ue")), HttpChallenge("Fancy", "yeah"))
       """WWW-Authenticate: Fancy realm="Secure Area",nonce=42""" =!=
         `WWW-Authenticate`(HttpChallenge("Fancy", "Secure Area", Map("nonce" -> "42")))


### PR DESCRIPTION
Fixes mandatory quotation of realm in HTTP auth challenge.
According to
http://greenbytes.de/tech/webdav/draft-ietf-httpbis-p7-auth-25.html#rfc.section.2.2.p.4