### PR TITLE
+ cache directives: add stale-while-revalidate

### DIFF
--- a/spray-http/src/main/scala/spray/http/CacheDirective.scala
+++ b/spray-http/src/main/scala/spray/http/CacheDirective.scala
@@ -41,14 +41,16 @@ object CacheDirective {
 object CacheDirectives {
   import CacheDirective._
 
+  trait ResponseDirectiveWithDeltaSeconds extends ResponseDirective with ValueRenderable with Product {
+    val deltaSeconds: Long
+    def render[R <: Rendering](r: R): r.type = r ~~ productPrefix ~~ '=' ~~ deltaSeconds
+  }
+
   /* Requests and Responses */
   case object `no-cache` extends SingletonValueRenderable with RequestDirective with ResponseDirective
   case object `no-store` extends SingletonValueRenderable with RequestDirective with ResponseDirective
   case object `no-transform` extends SingletonValueRenderable with RequestDirective with ResponseDirective
-
-  case class `max-age`(deltaSeconds: Long) extends RequestDirective with ResponseDirective with ValueRenderable {
-    def render[R <: Rendering](r: R): r.type = r ~~ productPrefix ~~ '=' ~~ deltaSeconds
-  }
+  case class `max-age`(deltaSeconds: Long) extends RequestDirective with ResponseDirectiveWithDeltaSeconds
 
   /* Requests only */
   case class `max-stale`(deltaSeconds: Option[Long]) extends RequestDirective with ValueRenderable {
@@ -64,7 +66,6 @@ object CacheDirectives {
 
   /* Responses only */
   case object `public` extends SingletonValueRenderable with ResponseDirective
-
   abstract class FieldNamesDirective extends Product with ValueRenderable {
     def fieldNames: Seq[String]
     def render[R <: Rendering](r: R): r.type =
@@ -83,7 +84,9 @@ object CacheDirectives {
   case class `no-cache`(fieldNames: String*) extends FieldNamesDirective with ResponseDirective
   case object `must-revalidate` extends SingletonValueRenderable with ResponseDirective
   case object `proxy-revalidate` extends SingletonValueRenderable with ResponseDirective
-  case class `s-maxage`(deltaSeconds: Long) extends ResponseDirective with ValueRenderable {
-    def render[R <: Rendering](r: R): r.type = r ~~ productPrefix ~~ '=' ~~ deltaSeconds
-  }
+  case class `s-maxage`(deltaSeconds: Long) extends ResponseDirectiveWithDeltaSeconds
+  /* The stale-while-revalidate Cache-Control Extension RFC-5861 http://tools.ietf.org/html/rfc5861#section-3 */
+  case class `stale-while-revalidate`(deltaSeconds: Long) extends ResponseDirectiveWithDeltaSeconds
+  /* The stale-if-error Cache-Control Extension RFC-5861 http://tools.ietf.org/html/rfc5861#section-4 */
+  case class `stale-if-error`(deltaSeconds: Long) extends ResponseDirectiveWithDeltaSeconds
 }

--- a/spray-http/src/main/scala/spray/http/parser/CacheControlHeader.scala
+++ b/spray-http/src/main/scala/spray/http/parser/CacheControlHeader.scala
@@ -44,6 +44,8 @@ private[parser] trait CacheControlHeader {
       | "must-revalidate" ~ push(`must-revalidate`)
       | "proxy-revalidate" ~ push(`proxy-revalidate`)
       | "s-maxage=" ~ DeltaSeconds ~~> (`s-maxage`(_))
+      | "stale-while-revalidate=" ~ DeltaSeconds ~~> (`stale-while-revalidate`(_))
+      | "stale-if-error=" ~ DeltaSeconds ~~> (`stale-if-error`(_))
 
       | Token ~ optional("=" ~ (Token | QuotedString)) ~~> (CacheDirective.custom(_, _)))
 

--- a/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
+++ b/spray-http/src/test/scala/spray/http/HttpHeaderSpec.scala
@@ -167,6 +167,10 @@ class HttpHeaderSpec extends Specification {
         `Cache-Control`(`private`("a", "b"), `no-cache`)
       "Cache-Control: private, community=\"<UCI>\"" =!=
         `Cache-Control`(`private`(), CacheDirective.custom("community", Some("<UCI>")))
+      "Cache-Control: stale-while-revalidate=30" =!=
+        `Cache-Control`(`stale-while-revalidate`(30))
+      "Cache-Control: stale-if-error=30" =!=
+        `Cache-Control`(`stale-if-error`(30))
     }
 
     "Connection" in {


### PR DESCRIPTION
RFC: 5861 'HTTP Cache-Control Extensions for Stale Content'

When present in an HTTP response, the stale-while-revalidate
Cache-Control extension indicates that caches MAY serve the response in
which it appears after it becomes stale, up to the indicated number of
seconds.

Rather than using a custom directive, it would be useful to have a standard
directive to add this header.

Ref: http://tools.ietf.org/html/rfc5861#section-3