### PR TITLE
+ spray-httpx,spray-routing-tests: marshaller oneOf

### DIFF
--- a/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
+++ b/spray-httpx/src/main/scala/spray/httpx/marshalling/Marshaller.scala
@@ -52,6 +52,24 @@ object Marshaller extends BasicMarshallers
         }
     }
 
+  def oneOf[T](marshalTo: ContentType*)(marshallers: Marshaller[T]*): Marshaller[T] =
+    Marshaller.of[T](marshalTo: _*) { (t, tpe, ctx) ⇒
+      def tryNext(marshallers: List[Marshaller[T]], previouslySupported: Set[ContentType]): Unit = marshallers match {
+        case head :: tail ⇒
+          head(t, new MarshallingContext {
+            def tryAccept(contentTypes: Seq[ContentType]): Option[ContentType] = ctx.tryAccept(contentTypes)
+            def rejectMarshalling(supported: Seq[ContentType]): Unit = tryNext(tail, previouslySupported ++ supported)
+            def marshalTo(entity: HttpEntity, headers: HttpHeader*): Unit = ctx.marshalTo(entity, headers: _*)
+            def handleError(error: Throwable): Unit = ctx.handleError(error)
+            def startChunkedMessage(entity: HttpEntity, ack: Option[Any] = None,
+                                    headers: Seq[HttpHeader] = Nil)(implicit sender: ActorRef): ActorRef =
+              ctx.startChunkedMessage(entity, ack, headers)(sender)
+          })
+        case Nil ⇒ ctx.rejectMarshalling(previouslySupported.toSeq)
+      }
+      tryNext(marshallers.toList, Set.empty)
+    }
+
   def delegate[A, B](marshalTo: ContentType*) = new MarshallerDelegation[A, B](marshalTo)
 
   class MarshallerDelegation[A, B](marshalTo: Seq[ContentType]) {

--- a/spray-routing-tests/src/test/scala/spray/routing/RouteDirectivesSpec.scala
+++ b/spray-routing-tests/src/test/scala/spray/routing/RouteDirectivesSpec.scala
@@ -107,7 +107,7 @@ class RouteDirectivesSpec extends RoutingSpec {
       }
     }
     "do Content-Type negotiation for multi-marshallers" in {
-      val route = get & complete(Data("Ida", 83))
+      val route = get & complete(OK -> Data("Ida", 83))
 
       import HttpHeaders.Accept
       Get().withHeaders(Accept(MediaTypes.`application/json`)) ~> route ~> check {
@@ -155,7 +155,7 @@ class RouteDirectivesSpec extends RoutingSpec {
         <data><name>{ data.name }</name><age>{ data.age }</age></data>
       }
 
-    implicit val dataMarshaller: ToResponseMarshaller[Data] =
-      ToResponseMarshaller.oneOf(MediaTypes.`application/json`, MediaTypes.`text/xml`)(jsonMarshaller, xmlMarshaller)
+    implicit val dataMarshaller: Marshaller[Data] =
+      Marshaller.oneOf(MediaTypes.`application/json`, MediaTypes.`text/xml`)(jsonMarshaller, xmlMarshaller)
   }
 }


### PR DESCRIPTION
To support content negotiation when creating a response with StatusCode -> Body
