### PR TITLE
= docs: add note that SSL configuration example is not meant to be a security recommendation

### DIFF
--- a/docs/documentation/spray-can/code/docs/HttpClientExamplesSpec.scala
+++ b/docs/documentation/spray-can/code/docs/HttpClientExamplesSpec.scala
@@ -10,6 +10,12 @@ class HttpClientExamplesSpec extends Specification with NoTimeConversions {
     import spray.io.ClientSSLEngineProvider
 
     implicit val myEngineProvider = ClientSSLEngineProvider { engine =>
+      // NOTE: The following lines are only meant as an example about how to change
+      //       Java's default configuration, not a recommendation about a secure or
+      //       otherwise reasonable Java default SSL configuration.
+      //
+      //       Security recommendations and TLS fixes are updated in a monthly fashion.
+      //       You need to inform yourself about what the current best practices are!
       engine.setEnabledCipherSuites(Array("TLS_RSA_WITH_AES_256_CBC_SHA"))
       engine.setEnabledProtocols(Array("SSLv3", "TLSv1"))
       engine

--- a/docs/documentation/spray-can/code/docs/HttpServerExamplesSpec.scala
+++ b/docs/documentation/spray-can/code/docs/HttpServerExamplesSpec.scala
@@ -44,6 +44,12 @@ class HttpServerExamplesSpec extends Specification {
     import spray.io.ServerSSLEngineProvider
 
     implicit val myEngineProvider = ServerSSLEngineProvider { engine =>
+      // NOTE: The following lines are only meant as an example about how to change
+      //       Java's default configuration, not a recommendation about a secure or
+      //       otherwise reasonable Java default SSL configuration.
+      //
+      //       Security recommendations and TLS fixes are updated in a monthly fashion.
+      //       You need to inform yourself about what the current best practices are!
       engine.setEnabledCipherSuites(Array("TLS_RSA_WITH_AES_256_CBC_SHA"))
       engine.setEnabledProtocols(Array("SSLv3", "TLSv1"))
       engine

--- a/examples/spray-can/simple-http-server/src/main/scala/spray/examples/MySslConfiguration.scala
+++ b/examples/spray-can/simple-http-server/src/main/scala/spray/examples/MySslConfiguration.scala
@@ -29,6 +29,12 @@ trait MySslConfiguration {
   // available here
   implicit def sslEngineProvider: ServerSSLEngineProvider = {
     ServerSSLEngineProvider { engine =>
+      // NOTE: The following lines are only meant as an example about how to change
+      //       Java's default configuration, not a recommendation about a secure or
+      //       otherwise reasonable Java default SSL configuration.
+      //
+      //       Security recommendations and TLS fixes are updated in a monthly fashion.
+      //       You need to inform yourself about what the current best practices are!
       engine.setEnabledCipherSuites(Array("TLS_RSA_WITH_AES_256_CBC_SHA"))
       engine.setEnabledProtocols(Array("SSLv3", "TLSv1"))
       engine


### PR DESCRIPTION
As people are CnPing this code everywhere misunderstanding its purpose.

E.g. see here:

http://stackoverflow.com/questions/31281571/sslhandshakeexception-no-cipher-suites-in-common-spray-can-ssl-configuration