### PR TITLE
Disallow type changes when a default value for a parameter is supplied

### DIFF
--- a/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/AnyParamDirectives.scala
@@ -92,6 +92,9 @@ object AnyParamDefMagnet2 {
   implicit def forNR[T](implicit fdma: FDMA[NameReceptacle[T], Directive1[T]],
                         pdma: PDMA[NameReceptacle[T], Directive1[T]]) = extractAnyParam[NameReceptacle[T], T](anyParamWrapper(_))
 
+  implicit def forTNR[T](implicit fdma: FDMA[TypedNameReceptacle[T], Directive1[T]],
+                         pdma: PDMA[TypedNameReceptacle[T], Directive1[T]]) = extractAnyParam[TypedNameReceptacle[T], T](anyParamWrapper(_))
+
   implicit def forNDefR[T](implicit fdma: FDMA[NameReceptacle[T], Directive1[T]],
                            pdma: PDMA[NameReceptacle[T], Directive1[T]]) =
     extractAnyParam[NameDefaultReceptacle[T], T](t ⇒ anyParamDefaultWrapper(NameReceptacle[T](t.name), t.default))

--- a/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/FormFieldDirectives.scala
@@ -89,6 +89,8 @@ object FieldDefMagnet2 extends ToNameReceptaclePimps {
     extractField[NameDeserializerDefaultReceptacle[T], T] { ndr ⇒
       filter(NameReceptacle[T](ndr.name))(ev1, FFC.fromFSOD(ndr.deserializer.withDefaultValue(ndr.default)))
     }
+  implicit def forTNR[T](implicit ev1: UM[HttpForm], ev2: FFC[T]) =
+    extractField[TypedNameReceptacle[T], T](nr ⇒ filter(NameReceptacle(nr.name)))
   implicit def forNR[T](implicit ev1: UM[HttpForm], ev2: FFC[T]) =
     extractField[NameReceptacle[T], T](nr ⇒ filter(nr))
 

--- a/spray-routing/src/main/scala/spray/routing/directives/NameReceptacle.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/NameReceptacle.scala
@@ -24,11 +24,17 @@ trait ToNameReceptaclePimps {
 }
 
 case class NameReceptacle[A](name: String) {
-  def as[B] = NameReceptacle[B](name)
+  def as[B] = new TypedNameReceptacle[B](name)
   def as[B](deserializer: FSOD[B]) = NameDeserializerReceptacle(name, deserializer)
-  def ? = as[Option[A]]
+  def ? = new NameReceptacle[Option[A]](name)
   def ?[B](default: B) = NameDefaultReceptacle(name, default)
   def ![B](requiredValue: B) = RequiredValueReceptacle(name, requiredValue)
+}
+
+case class TypedNameReceptacle[A](name: String) {
+  def ? = new TypedNameReceptacle[Option[A]](name)
+  def ?[B <: A](default: B) = NameDefaultReceptacle[A](name, default)
+  def ![B <: A](requiredValue: B) = RequiredValueReceptacle[A](name, requiredValue)
 }
 
 case class NameDeserializerReceptacle[A](name: String, deserializer: FSOD[A]) {

--- a/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
+++ b/spray-routing/src/main/scala/spray/routing/directives/ParameterDirectives.scala
@@ -112,6 +112,9 @@ object ParamDefMagnet2 {
   implicit def forNDesDefR[T] = extractParameter[NameDeserializerDefaultReceptacle[T], T] { nr ⇒
     filter(nr.name, nr.deserializer.withDefaultValue(nr.default))
   }
+  implicit def forTNR[T](implicit fsod: FSOD[T]) = extractParameter[TypedNameReceptacle[T], T] { nr ⇒
+    filter(nr.name, fsod)
+  }
   implicit def forNR[T](implicit fsod: FSOD[T]) = extractParameter[NameReceptacle[T], T] { nr ⇒
     filter(nr.name, fsod)
   }


### PR DESCRIPTION
This pull request disallows type changes in the `NameReceptacle` class, when it has already been typed through the `as` method. Previously, one could have a parameter under the `parameters` directive defined as `'v.as[Int] ? "a-string"` and the parameter would be incorrectly typed as a `String`. This patch disallows the previous statement. This also enables subtypes as default values when using a designated unmarshaller. A test exposing this has also been added.

I was not sure on how to properly label the commit. This has the potential of breaking user code if someone was defining parameters as previously stated, but I consider that a misuse, so I decided to go with the neutral category.

Also, I understand that there are no currently planned spray releases. I'm not familiar with `akka-http` yet, but I'd be happy to provide a similar patch if this is an issue there as well.
