### PR TITLE
Reply with HttpClientConnection-Ref

### DIFF
--- a/spray-can/src/main/scala/spray/can/client/HttpClientConnection.scala
+++ b/spray-can/src/main/scala/spray/can/client/HttpClientConnection.scala
@@ -48,7 +48,7 @@ private class HttpClientConnection(connectCommander: ActorRef,
       // if sslEncryption is enabled we may need keepOpenOnPeerClosed
       tcpConnection ! Tcp.Register(self, keepOpenOnPeerClosed = connect.sslEncryption)
       context.watch(tcpConnection)
-      connectCommander ! connected
+      connectCommander ! self
       context.become(running(tcpConnection, pipelineStage, pipelineContext(connected)))
 
     case Tcp.CommandFailed(_: Tcp.Connect) ⇒


### PR DESCRIPTION
The TCP.Connected instance isn't of much use to the client of the HttpClientConnection. However it would be good if a reference to the HttpClientConnection was available. The HostConnectorSetup returns such a self reference, albeit wrapped into a Http.HostConnectorInfo 

Also, it seems like a violation of the layering to return underlying Tcp object.