### PR TITLE
Ignore SetRequestTimeout/SetTimeoutTimeout messages

### DIFF
--- a/spray-testkit/src/main/scala/spray/testkit/RouteResultComponent.scala
+++ b/spray-testkit/src/main/scala/spray/testkit/RouteResultComponent.scala
@@ -61,6 +61,10 @@ trait RouteResultComponent {
           case HttpMessagePartWrapper(ChunkedMessageEnd(extension, trailer), _) ⇒
             synchronized { _closingExtension = extension; _trailer = trailer }
             latch.countDown()
+          case SetRequestTimeout(_) =>
+            // NOOP
+          case SetTimeoutTimeout(_) =>
+            // NOOP
           case Status.Failure(error) ⇒
             sys.error("Route produced exception: " + error)
           case x ⇒


### PR DESCRIPTION
<img width="809" alt="screen shot 2015-11-13 at 4 25 28 pm" src="https://cloud.githubusercontent.com/assets/1162120/11160799/f887b062-8a23-11e5-92e4-e496d56f44fd.png">

I implemented a file upload actor similar to [the spray's example](https://github.com/spray/spray/blob/master/examples/spray-can/simple-http-server/src/main/scala/spray/examples/FileUploadHandler.scala) but spray-testkit doesn't allow `SetRequestTimeout` to receive. I think we can just ignore this message in the test.