### PR TITLE
=routing backport to fix directory traversal in getFromDirectory / listDirectoryContents on Windows

### DIFF
--- a/spray-routing-tests/src/test/resources/dirWithLink/linked-dir
+++ b/spray-routing-tests/src/test/resources/dirWithLink/linked-dir
@@ -1,0 +1,1 @@
+../subDirectory

--- a/spray-routing-tests/src/test/resources/sübdir/sample späce.PDF
+++ b/spray-routing-tests/src/test/resources/sübdir/sample späce.PDF
@@ -1,0 +1,1 @@
+This is PDF


### PR DESCRIPTION
Backport from akka/akka-http#348.

See akka/akka-http#346 for the original issue.

@sirthias I think it would make sense to publish a new version of spray to fix this problem. It is only a problem on Windows but there it is quite ugly for people using the directive. I only backported the fix for 1.3.x so far. It would probably also apply cleanly to versions 1.0.x to 1.2.x but to signify that those are definitely EOL'd by now, we might want to wait for explicit requests before putting more work into that. WDYT?